### PR TITLE
Refactor lancedb_record_batch_reader_from_arrow to improve error handling

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -91,17 +91,31 @@ This example shows how to create a LanceDB table with vector data using Apache A
 
 .. code-block:: c
 
+   LanceDBError result;
+   char* error_message = NULL;
+
    // Create reader from Arrow C ABI
-   LanceDBRecordBatchReader* reader = lancedb_record_batch_reader_from_arrow(
+   LanceDBRecordBatchReader* reader;
+
+   result = lancedb_record_batch_reader_from_arrow(
        (FFI_ArrowArray*)&c_array,
-       (FFI_ArrowSchema*)&c_schema
+       (FFI_ArrowSchema*)&c_schema,
+       &reader,
+       &error_message
    );
+
+   if (result != LANCEDB_SUCCESS) {
+       fprintf(stderr, "Error: %s\n", error_message);
+       lancedb_free_string(error_message);
+       if (c_array.release) {
+         c_array.release(&c_array);
+       }
+   }
 
    // Create table
    LanceDBTable* table;
-   char* error_message = NULL;
 
-   LanceDBError result = lancedb_table_create(
+   result = lancedb_table_create(
        db,
        "my_vectors",
        (FFI_ArrowSchema*)&c_schema,

--- a/examples/full.cpp
+++ b/examples/full.cpp
@@ -253,9 +253,11 @@ int main() {
   if (const auto status = arrow::ExportRecordBatch(*record_batch, &c_array, &c_schema); !status.ok()) {
     std::cerr << "failed to export record batch to C ABI: " << status.ToString() << std::endl;
   } else {
-    if (auto batch_reader = lancedb_record_batch_reader_from_arrow(
+    LanceDBRecordBatchReader* batch_reader;
+    if (const LanceDBError error = lancedb_record_batch_reader_from_arrow(
           reinterpret_cast<FFI_ArrowArray*>(&c_array),
-          reinterpret_cast<FFI_ArrowSchema*>(&c_schema)); batch_reader) {
+          reinterpret_cast<FFI_ArrowSchema*>(&c_schema),
+          &batch_reader, nullptr); error == LANCEDB_SUCCESS) {
       // add data to table
       if (const LanceDBError result = lancedb_table_add(tbl, batch_reader, nullptr); result != LANCEDB_SUCCESS) {
         std::cerr << "failed to write record batch to table, error: " << lancedb_error_to_message(result) << std::endl;
@@ -264,7 +266,9 @@ int main() {
       }
     } else {
       std::cerr << "failed to create record batch reader from arrow arrays" << std::endl;
-      lancedb_record_batch_reader_free(batch_reader);
+      if (c_array.release) {
+        c_array.release(&c_array);
+      }
     }
   }
 
@@ -502,9 +506,11 @@ int main() {
         if (const auto status = arrow::ExportRecordBatch(*record_batch, &c_array, &c_schema); !status.ok()) {
           std::cerr << "failed to export record batch to C ABI: " << status.ToString() << std::endl;
         } else {
-          if (auto batch_reader = lancedb_record_batch_reader_from_arrow(
+          LanceDBRecordBatchReader* batch_reader;
+          if (const LanceDBError error = lancedb_record_batch_reader_from_arrow(
                 reinterpret_cast<FFI_ArrowArray*>(&c_array),
-                reinterpret_cast<FFI_ArrowSchema*>(&c_schema)); batch_reader) {
+                reinterpret_cast<FFI_ArrowSchema*>(&c_schema),
+                &batch_reader, nullptr); error == LANCEDB_SUCCESS) {
             // upsert the new data to table
             std::array<const char*, 1> on_columns = {"key"};
             //
@@ -523,7 +529,9 @@ int main() {
             }
           } else {
             std::cerr << "failed to create record batch reader from arrow arrays" << std::endl;
-            lancedb_record_batch_reader_free(batch_reader);
+            if (c_array.release) {
+              c_array.release(&c_array);
+            }
           }
         }
 

--- a/examples/simple.cpp
+++ b/examples/simple.cpp
@@ -73,11 +73,15 @@ LanceDBTable* create_table(LanceDBConnection* db) {
     return nullptr;
   }
 
-  LanceDBRecordBatchReader* reader = lancedb_record_batch_reader_from_arrow(
+  LanceDBRecordBatchReader* reader;
+  if (const LanceDBError result = lancedb_record_batch_reader_from_arrow(
       reinterpret_cast<FFI_ArrowArray*>(&c_array),
-      reinterpret_cast<FFI_ArrowSchema*>(&c_schema));
-  if (!reader) {
+      reinterpret_cast<FFI_ArrowSchema*>(&c_schema),
+      &reader, nullptr); result != LANCEDB_SUCCESS) {
     std::cerr << "failed to create record batch reader from arrow arrays" << std::endl;
+    if (c_array.release) {
+      c_array.release(&c_array);
+    }
     return nullptr;
   }
 
@@ -98,10 +102,10 @@ LanceDBTable* create_table(LanceDBConnection* db) {
     return nullptr;
   }
 
-  reader = lancedb_record_batch_reader_from_arrow(
+  if (const LanceDBError result = lancedb_record_batch_reader_from_arrow(
       reinterpret_cast<FFI_ArrowArray*>(&c_array),
-      reinterpret_cast<FFI_ArrowSchema*>(&c_schema));
-  if (!reader) {
+      reinterpret_cast<FFI_ArrowSchema*>(&c_schema),
+      &reader, nullptr); result != LANCEDB_SUCCESS) {
     std::cerr << "failed to create record batch reader from arrow arrays" << std::endl;
     if (c_array.release) {
       c_array.release(&c_array);

--- a/include/lancedb.h
+++ b/include/lancedb.h
@@ -1059,17 +1059,22 @@ LanceDBError lancedb_table_nearest_to(
  *
  * @param array - pointer to FFI_ArrowArray containing record batch data
  * @param schema - pointer to FFI_ArrowSchema containing the schema
- * @return Pointer to LanceDBRecordBatchReader on success, NULL on failure
+ * @param reader_out - pointer to receive the created reader
+ * @param error_message - optional pointer to receive detailed error message (NULL to ignore)
+ * @return Error code indicating success or failure
  *
  * This function consumes the array according to Arrow C ABI specification.
  * The caller should NOT call the array's release function after passing it here.
  * The schema is only read and should still be released by the caller.
  * The caller is responsible for freeing the returned reader with
- * lancedb_record_batch_reader_free().
+ * lancedb_record_batch_reader_free(). If error_message is provided and an error
+ * occurs, the caller must free the error message with lancedb_free_string().
  */
-LanceDBRecordBatchReader* lancedb_record_batch_reader_from_arrow(
+LanceDBError lancedb_record_batch_reader_from_arrow(
     const struct FFI_ArrowArray* array,
-    const struct FFI_ArrowSchema* schema
+    const struct FFI_ArrowSchema* schema,
+    LanceDBRecordBatchReader** reader_out,
+    char** error_message
 );
 
 /**

--- a/src/table.rs
+++ b/src/table.rs
@@ -253,23 +253,30 @@ pub unsafe extern "C" fn lancedb_table_restore_version(
 /// # Safety
 /// - `array` must be a valid pointer to FFI_ArrowArray containing the record batch data
 /// - `schema` must be a valid pointer to FFI_ArrowSchema containing the schema
+/// - `reader_out` must be a valid pointer to receive the created reader
+/// - `error_message` can be NULL to ignore detailed error messages
 /// - The caller is responsible for ensuring the array and schema are properly formatted
 ///
 /// # Returns
-/// - Pointer to LanceDBRecordBatchReader wrapper, or NULL on failure
+/// - Error code indicating success or failure
 #[no_mangle]
 pub unsafe extern "C" fn lancedb_record_batch_reader_from_arrow(
     array: *const arrow_array::ffi::FFI_ArrowArray,
     schema: *const arrow_schema::ffi::FFI_ArrowSchema,
-) -> *mut LanceDBRecordBatchReader {
-    if array.is_null() || schema.is_null() {
-        return ptr::null_mut();
+    reader_out: *mut *mut LanceDBRecordBatchReader,
+    error_message: *mut *mut c_char,
+) -> LanceDBError {
+    if array.is_null() || schema.is_null() || reader_out.is_null() {
+        set_invalid_argument_message(error_message);
+        return LanceDBError::InvalidArgument;
     }
 
     // Import the schema from C ABI
     let imported_schema = match Schema::try_from(&*schema) {
         Ok(schema) => std::sync::Arc::new(schema),
-        Err(_) => return ptr::null_mut(),
+        Err(e) => {
+            return handle_error(&lancedb::error::Error::Arrow { source: e }, error_message);
+        }
     };
 
     // Import the array from C ABI and convert to RecordBatch
@@ -281,7 +288,9 @@ pub unsafe extern "C" fn lancedb_record_batch_reader_from_arrow(
             let struct_array = StructArray::from(array_data);
             RecordBatch::from(&struct_array)
         }
-        Err(_) => return ptr::null_mut(),
+        Err(e) => {
+            return handle_error(&lancedb::error::Error::Arrow { source: e }, error_message);
+        }
     };
 
     // Note: According to Arrow C ABI specification, this function consumes the array.
@@ -321,7 +330,8 @@ pub unsafe extern "C" fn lancedb_record_batch_reader_from_arrow(
 
     let wrapper = Box::new(LanceDBRecordBatchReader::new(Box::new(reader)));
 
-    Box::into_raw(wrapper)
+    *reader_out = Box::into_raw(wrapper);
+    LanceDBError::Success
 }
 
 /// Free a RecordBatchReader wrapper

--- a/tests/test_common.cpp
+++ b/tests/test_common.cpp
@@ -133,9 +133,11 @@ LanceDBRecordBatchReader* create_reader_from_batch(const std::shared_ptr<arrow::
 
   REQUIRE(arrow::ExportRecordBatch(*batch, &c_array, &c_schema).ok());
 
-  auto reader = lancedb_record_batch_reader_from_arrow(
+  LanceDBRecordBatchReader* reader;
+  lancedb_record_batch_reader_from_arrow(
       reinterpret_cast<FFI_ArrowArray*>(&c_array),
-      reinterpret_cast<FFI_ArrowSchema*>(&c_schema));
+      reinterpret_cast<FFI_ArrowSchema*>(&c_schema),
+      &reader, nullptr);
 
   // Schema is only read by the function, so we must release it
   if (c_schema.release) {

--- a/tests/test_table.cpp
+++ b/tests/test_table.cpp
@@ -563,3 +563,122 @@ TEST_CASE_METHOD(LanceDBFixture, "LanceDB Table Merge Insert", "[table]") {
   lancedb_table_free(table);
 }
 
+TEST_CASE_METHOD(LanceDBFixture, "LanceDB Create Reader", "[table]") {
+  constexpr auto row_num = 10;
+  auto batch = create_test_record_batch(row_num, 0);
+
+  SECTION("Successfully create reader") {
+    struct ArrowArray c_array;
+    struct ArrowSchema c_schema;
+
+    REQUIRE(arrow::ExportRecordBatch(*batch, &c_array, &c_schema).ok());
+
+    LanceDBRecordBatchReader* reader = nullptr;
+    char* error_message = nullptr;
+    // We expect success here
+    LanceDBError result = lancedb_record_batch_reader_from_arrow(
+      reinterpret_cast<FFI_ArrowArray*>(&c_array),
+      reinterpret_cast<FFI_ArrowSchema*>(&c_schema),
+      &reader,
+      &error_message);
+
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(reader);
+    REQUIRE(error_message == nullptr);
+
+    // According to docs/code: Schema is only read by the function, so we must release it.
+    // The array IS CONSUMED by definition of the function (though technically checked early before consumption, if success occurs, array is consumed).
+    if (c_schema.release) {
+      c_schema.release(&c_schema);
+    }
+
+    // We must free the reader
+    lancedb_record_batch_reader_free(reader);
+  }
+
+  SECTION("Create reader with null array") {
+    struct ArrowArray c_array;
+    struct ArrowSchema c_schema;
+
+    REQUIRE(arrow::ExportRecordBatch(*batch, &c_array, &c_schema).ok());
+
+    LanceDBRecordBatchReader* reader = nullptr;
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_record_batch_reader_from_arrow(
+      nullptr,
+      reinterpret_cast<FFI_ArrowSchema*>(&c_schema),
+      &reader,
+      &error_message);
+
+    REQUIRE(result == LANCEDB_INVALID_ARGUMENT);
+    REQUIRE(reader == nullptr);
+    REQUIRE(error_message);
+
+    lancedb_free_string(error_message);
+
+    // Since it failed early (null check), array was not consumed.
+    if (c_array.release) {
+      c_array.release(&c_array);
+    }
+    if (c_schema.release) {
+      c_schema.release(&c_schema);
+    }
+  }
+
+  SECTION("Create reader with null schema") {
+    struct ArrowArray c_array;
+    struct ArrowSchema c_schema;
+
+    REQUIRE(arrow::ExportRecordBatch(*batch, &c_array, &c_schema).ok());
+
+    LanceDBRecordBatchReader* reader = nullptr;
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_record_batch_reader_from_arrow(
+      reinterpret_cast<FFI_ArrowArray*>(&c_array),
+      nullptr,
+      &reader,
+      &error_message);
+
+    REQUIRE(result == LANCEDB_INVALID_ARGUMENT);
+    REQUIRE(reader == nullptr);
+    REQUIRE(error_message);
+
+    lancedb_free_string(error_message);
+
+    // Since it failed early, array was not consumed.
+    if (c_array.release) {
+      c_array.release(&c_array);
+    }
+    if (c_schema.release) {
+      c_schema.release(&c_schema);
+    }
+  }
+
+  SECTION("Create reader with null output pointer") {
+    struct ArrowArray c_array;
+    struct ArrowSchema c_schema;
+
+    REQUIRE(arrow::ExportRecordBatch(*batch, &c_array, &c_schema).ok());
+
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_record_batch_reader_from_arrow(
+      reinterpret_cast<FFI_ArrowArray*>(&c_array),
+      reinterpret_cast<FFI_ArrowSchema*>(&c_schema),
+      nullptr,
+      &error_message);
+
+    REQUIRE(result == LANCEDB_INVALID_ARGUMENT);
+    REQUIRE(error_message);
+
+    lancedb_free_string(error_message);
+
+    // Since it failed early, array was not consumed.
+    if (c_array.release) {
+      c_array.release(&c_array);
+    }
+    if (c_schema.release) {
+      c_schema.release(&c_schema);
+    }
+  }
+}
+


### PR DESCRIPTION
## Description
This PR refactors `lancedb_record_batch_reader_from_arrow` to return a `LanceDBError` code and an optional error message, aligning it with other fallible APIs in the library. Previously, this function returned `NULL` on failure, providing no context on why the Arrow import failed (e.g., schema validation errors vs. array import errors). This closes #7.

## Changes
- **API Breaking Change**: `lancedb_record_batch_reader_from_arrow` now returns `LanceDBError` instead of a pointer.
  - Added output parameter `LanceDBRecordBatchReader** reader_out`.
  - Added output parameter `char** error_message`.
- **Implementation**: Updated Rust FFI implementation in [src/table.rs](src/table.rs) to catch and report errors during `Schema` and `RecordBatch` import from the Arrow C ABI using `handle_error`.
- **Documentation**: Updated [include/lancedb.h](include/lancedb.h) and [docs/index.rst](docs/index.rst) to reflect the new signature and memory management rules (caller must free the error message if provided).
- **Examples & Tests**: Updated [examples/full.cpp](examples/full.cpp), [examples/simple.cpp](examples/simple.cpp), and [tests/test_common.cpp](tests/test_common.cpp) to handle the new return type and properly call the Arrow `release` function if the import fails.

## Breaking Changes
The signature of `lancedb_record_batch_reader_from_arrow` in [include/lancedb.h](include/lancedb.h) has changed.

## Checklist
- [x] API updated in [include/lancedb.h](include/lancedb.h)
- [x] Implementation updated in [src/table.rs](src/table.rs)
- [x] Examples updated ([examples/simple.cpp](examples/simple.cpp), [examples/full.cpp](examples/full.cpp))
- [x] Tests updated ([tests/test_common.cpp](tests/test_common.cpp))
- [x] Documentation updated ([docs/index.rst](docs/index.rst))