### PR TITLE
Windows CI: Switch to UCRT64 and use runner toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,9 @@ jobs:
       - uses: msys2/setup-msys2@v2
         if: matrix.os == 'windows-latest'
         with:
+          msystem: ucrt64
           path-type: inherit
-          install: mingw-w64-x86_64-arrow mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja mingw-w64-x86_64-toolchain mingw-w64-x86_64-protobuf
+          install: mingw-w64-ucrt-x86_64-arrow mingw-w64-ucrt-x86_64-protobuf
 
       - name: Configure CMake
         if: matrix.os != 'windows-latest'


### PR DESCRIPTION
This PR updates the Windows CI workflow to use the `ucrt64` MSYS2 environment.

**Changes:**
- Configured MSYS2 to use `msystem: ucrt64`.
- Updated dependencies to use UCRT variants (`mingw-w64-ucrt-x86_64-arrow`, `mingw-w64-ucrt-x86_64-protobuf`).
- Removed explicit installation of `cmake`, `ninja`, and the GCC toolchain to rely on the build tools provided by the runner environment (via `path-type: inherit`).

**Motivation:**
To leverage the Universal C Runtime (UCRT) and reduce CI setup time by utilizing pre-installed tools on the runner.