### PR TITLE
feat: add v1 of session apis

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,23 @@ This example shows how to create a LanceDB table with vector data using Apache A
    LanceDBConnectBuilder* builder = lancedb_connect("./my_database");
    LanceDBConnection* db = lancedb_connect_builder_execute(builder);
 
+.. note::
+
+   You can optionally configure session cache sizes and attach the session to
+   the connection builder:
+
+   .. code-block:: c
+
+      LanceDBSessionOptions options = {0};
+      options.index_cache_bytes = 512 * 1024 * 1024;
+      options.metadata_cache_bytes = 256 * 1024 * 1024;
+
+      LanceDBSession* session = lancedb_session_new(&options);
+
+      LanceDBConnectBuilder* builder = lancedb_connect("./my_database");
+      builder = lancedb_connect_builder_session(builder, session);
+      LanceDBConnection* db = lancedb_connect_builder_execute(builder);
+
 **2. Create Arrow schema (using Arrow C++ API):**
 
 .. code-block:: cpp

--- a/include/lancedb.h
+++ b/include/lancedb.h
@@ -8,6 +8,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,6 +48,11 @@ typedef struct LanceDBVectorQuery LanceDBVectorQuery;
  * Opaque handle to a LanceDB QueryResult
  */
 typedef struct LanceDBQueryResult LanceDBQueryResult;
+
+/**
+ * Opaque handle to a LanceDB Session
+ */
+typedef struct LanceDBSession LanceDBSession;
 
 /**
  * Opaque handle to Arrow RecordBatchReader
@@ -214,6 +220,24 @@ typedef struct {
 } LanceDBMergeInsertConfig;
 
 /**
+ * Session creation options
+ */
+typedef struct {
+    size_t index_cache_bytes;        // Index cache size in bytes (0 = default)
+    size_t metadata_cache_bytes;     // Metadata cache size in bytes (0 = default)
+} LanceDBSessionOptions;
+
+/**
+ * Session cache statistics
+ */
+typedef struct {
+    uint64_t hits;          // Number of cache hits
+    uint64_t misses;        // Number of cache misses
+    size_t num_entries;     // Number of entries in cache
+    size_t size_bytes;      // Cache size in bytes
+} LanceDBSessionCacheStats;
+
+/**
  * Version information for a table
  */
 typedef struct {
@@ -271,6 +295,18 @@ LanceDBConnection* lancedb_connect_builder_execute(LanceDBConnectBuilder* builde
  * with unsupported key or value.
  */
 LanceDBConnectBuilder* lancedb_connect_builder_storage_option(LanceDBConnectBuilder* builder, const char* key, const char* value);
+
+/**
+ * Set session for the connection builder
+ *
+ * @param builder - pointer to LanceDBConnectBuilder returned from lancedb_connect()
+ * @param session - pointer to LanceDBSession, or NULL to keep current/default session behavior
+ * @return Non-null pointer to LanceDBConnectBuilder on success, NULL on failure
+ *
+ * The builder is consumed by this function and must not be used after calling.
+ * Passing NULL session is a no-op.
+ */
+LanceDBConnectBuilder* lancedb_connect_builder_session(LanceDBConnectBuilder* builder, const LanceDBSession* session);
 
 /**
  * Free a ConnectBuilder
@@ -541,6 +577,59 @@ void lancedb_free_namespace_list(char** namespaces, size_t count);
  * After calling this function, the connection pointer must not be used.
  */
 void lancedb_connection_free(LanceDBConnection* connection);
+
+/**
+ * Create a new session
+ *
+ * @param options - pointer to LanceDBSessionOptions, or NULL for defaults
+ * @return Non-null pointer to LanceDBSession on success, NULL on failure
+ *
+ * The returned session must be freed with lancedb_session_free().
+ */
+LanceDBSession* lancedb_session_new(const LanceDBSessionOptions* options);
+
+/**
+ * Get index cache stats for a session
+ *
+ * @param session - pointer to LanceDBSession
+ * @param out_stats - pointer to receive session cache statistics
+ * @param error_message - optional pointer to receive detailed error message (NULL to ignore)
+ * @return Error code indicating success or failure
+ *
+ * If error_message is provided and an error occurs, the caller must free
+ * the error message with lancedb_free_string().
+ */
+LanceDBError lancedb_session_index_cache_stats(
+    const LanceDBSession* session,
+    LanceDBSessionCacheStats* out_stats,
+    char** error_message
+);
+
+/**
+ * Get metadata cache stats for a session
+ *
+ * @param session - pointer to LanceDBSession
+ * @param out_stats - pointer to receive session cache statistics
+ * @param error_message - optional pointer to receive detailed error message (NULL to ignore)
+ * @return Error code indicating success or failure
+ *
+ * If error_message is provided and an error occurs, the caller must free
+ * the error message with lancedb_free_string().
+ */
+LanceDBError lancedb_session_metadata_cache_stats(
+    const LanceDBSession* session,
+    LanceDBSessionCacheStats* out_stats,
+    char** error_message
+);
+
+/**
+ * Free a Session
+ *
+ * @param session - pointer to LanceDBSession
+ *
+ * After calling this function, the session pointer must not be used.
+ */
+void lancedb_session_free(LanceDBSession* session);
 
 /**
  * Free a Table

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -46,6 +46,31 @@ pub struct LanceDBTableNamesBuilder {
     inner: Box<TableNamesBuilder>,
 }
 
+/// Opaque handle to a Session
+#[repr(C)]
+pub struct LanceDBSession {
+    inner: Arc<lancedb::Session>,
+}
+
+/// Session creation options
+#[repr(C)]
+pub struct LanceDBSessionOptions {
+    pub index_cache_bytes: usize,
+    pub metadata_cache_bytes: usize,
+}
+
+/// Cache statistics for a session cache
+#[repr(C)]
+pub struct LanceDBSessionCacheStats {
+    pub hits: u64,
+    pub misses: u64,
+    pub num_entries: usize,
+    pub size_bytes: usize,
+}
+
+const DEFAULT_INDEX_CACHE_SIZE_BYTES: usize = 6 * 1024 * 1024 * 1024;
+const DEFAULT_METADATA_CACHE_SIZE_BYTES: usize = 1024 * 1024 * 1024;
+
 /// Runtime to handle async operations
 static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 
@@ -157,6 +182,42 @@ pub unsafe extern "C" fn lancedb_connect_builder_storage_option(
     Box::into_raw(boxed_builder)
 }
 
+/// Set a session for the connection builder
+///
+/// # Safety
+/// - `builder` must be a valid pointer returned from `lancedb_connect`
+/// - `builder` will be consumed and must not be used after calling this function
+/// - `session` can be NULL (no-op) or a valid pointer returned from `lancedb_session_new`
+///
+/// # Returns
+/// - A new pointer to LanceDBConnectBuilder on success
+/// - Null pointer on failure
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_connect_builder_session(
+    builder: *mut LanceDBConnectBuilder,
+    session: *const LanceDBSession,
+) -> *mut LanceDBConnectBuilder {
+    if builder.is_null() {
+        return ptr::null_mut();
+    }
+
+    let builder_box = Box::from_raw(builder);
+    let connect_builder = *builder_box.inner;
+
+    let updated_builder = if session.is_null() {
+        connect_builder
+    } else {
+        let session_ref = &*session;
+        connect_builder.session(session_ref.inner.clone())
+    };
+
+    let boxed_builder = Box::new(LanceDBConnectBuilder {
+        inner: Box::new(updated_builder),
+    });
+
+    Box::into_raw(boxed_builder)
+}
+
 /// Free a ConnectBuilder
 ///
 /// # Safety
@@ -197,6 +258,116 @@ pub unsafe extern "C" fn lancedb_connection_uri(
     });
 
     cached_uri.as_ptr()
+}
+
+/// Create a new session
+///
+/// # Safety
+/// - `options` can be NULL to use default session configuration
+///
+/// # Returns
+/// - Non-null pointer to LanceDBSession on success
+/// - Null pointer on failure
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_session_new(
+    options: *const LanceDBSessionOptions,
+) -> *mut LanceDBSession {
+    let session = if options.is_null() {
+        Arc::new(lancedb::Session::default())
+    } else {
+        let session_options = &*options;
+        let index_cache_bytes = if session_options.index_cache_bytes == 0 {
+            DEFAULT_INDEX_CACHE_SIZE_BYTES
+        } else {
+            session_options.index_cache_bytes
+        };
+        let metadata_cache_bytes = if session_options.metadata_cache_bytes == 0 {
+            DEFAULT_METADATA_CACHE_SIZE_BYTES
+        } else {
+            session_options.metadata_cache_bytes
+        };
+        Arc::new(lancedb::Session::new(
+            index_cache_bytes,
+            metadata_cache_bytes,
+            Arc::new(lancedb::ObjectStoreRegistry::default()),
+        ))
+    };
+
+    Box::into_raw(Box::new(LanceDBSession { inner: session }))
+}
+
+/// Get index cache stats for a session
+///
+/// # Safety
+/// - `session` must be a valid pointer returned from `lancedb_session_new`
+/// - `out_stats` must be a valid pointer to receive cache stats
+/// - `error_message` can be NULL to ignore detailed error messages
+///
+/// # Returns
+/// - Error code indicating success or failure
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_session_index_cache_stats(
+    session: *const LanceDBSession,
+    out_stats: *mut LanceDBSessionCacheStats,
+    error_message: *mut *mut c_char,
+) -> LanceDBError {
+    if session.is_null() || out_stats.is_null() {
+        set_invalid_argument_message(error_message);
+        return LanceDBError::InvalidArgument;
+    }
+
+    let session_ref = &*session;
+    let stats = get_runtime().block_on(session_ref.inner.index_cache_stats());
+    *out_stats = LanceDBSessionCacheStats {
+        hits: stats.hits,
+        misses: stats.misses,
+        num_entries: stats.num_entries,
+        size_bytes: stats.size_bytes,
+    };
+    LanceDBError::Success
+}
+
+/// Get metadata cache stats for a session
+///
+/// # Safety
+/// - `session` must be a valid pointer returned from `lancedb_session_new`
+/// - `out_stats` must be a valid pointer to receive cache stats
+/// - `error_message` can be NULL to ignore detailed error messages
+///
+/// # Returns
+/// - Error code indicating success or failure
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_session_metadata_cache_stats(
+    session: *const LanceDBSession,
+    out_stats: *mut LanceDBSessionCacheStats,
+    error_message: *mut *mut c_char,
+) -> LanceDBError {
+    if session.is_null() || out_stats.is_null() {
+        set_invalid_argument_message(error_message);
+        return LanceDBError::InvalidArgument;
+    }
+
+    let session_ref = &*session;
+    let stats = get_runtime().block_on(session_ref.inner.metadata_cache_stats());
+    *out_stats = LanceDBSessionCacheStats {
+        hits: stats.hits,
+        misses: stats.misses,
+        num_entries: stats.num_entries,
+        size_bytes: stats.size_bytes,
+    };
+    LanceDBError::Success
+}
+
+/// Free a Session
+///
+/// # Safety
+/// - `session` must be a valid pointer returned from `lancedb_session_new`
+/// - `session` must not be used after calling this function
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_session_free(session: *mut LanceDBSession) {
+    if !session.is_null() {
+        let _ = Box::from_raw(session);
+    }
 }
 
 /// Create a new table with Arrow schema and data

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -73,6 +73,27 @@ public:
   LanceDBTable* create_table_with_data(const std::string& table_name, int num_rows, int start_index);
 };
 
+class LanceDBSessionFixture : public LanceDBFixture {
+  protected: 
+    LanceDBSession* session = nullptr;
+    LanceDBSessionOptions session_options = {.index_cache_bytes = 1024 * 1024, .metadata_cache_bytes = 512 * 1024};
+  public:
+    LanceDBSessionFixture() {
+      lancedb_connection_free(db);
+      LanceDBConnectBuilder* builder = lancedb_connect(uri.c_str());
+      REQUIRE(builder != nullptr);
+      session = lancedb_session_new(&session_options);
+      REQUIRE(session != nullptr);
+      builder = lancedb_connect_builder_session(builder, session);
+      db = lancedb_connect_builder_execute(builder);
+      REQUIRE(db != nullptr);
+    }
+
+    ~LanceDBSessionFixture() {
+      lancedb_session_free(session);
+    }
+};
+
 // Test schema dimensions constant
 constexpr size_t TEST_SCHEMA_DIMENSIONS = 8;
 

--- a/tests/test_connection.cpp
+++ b/tests/test_connection.cpp
@@ -24,6 +24,8 @@ TEST_CASE_METHOD(BaseFixture, "LanceDB Connection Builder", "[connection]") {
     REQUIRE(builder != nullptr);
     builder = lancedb_connect_builder_storage_option(builder, "hello", "world");
     REQUIRE(builder != nullptr);
+    builder = lancedb_connect_builder_session(builder, nullptr);
+    REQUIRE(builder != nullptr);
     LanceDBConnection* db = lancedb_connect_builder_execute(builder);
     REQUIRE(db != nullptr);
     lancedb_connection_free(db);
@@ -60,6 +62,81 @@ TEST_CASE_METHOD(BaseFixture, "LanceDB Connection Builder", "[connection]") {
     REQUIRE(builder != nullptr);
     builder = lancedb_connect_builder_storage_option(builder, "hello", NON_UTF8);
     REQUIRE(builder == nullptr);
+  }
+  SECTION("Attach session to connect builder") {
+    LanceDBSession* session = lancedb_session_new(nullptr);
+    REQUIRE(session != nullptr);
+    LanceDBConnectBuilder* builder = lancedb_connect(uri.c_str());
+    REQUIRE(builder != nullptr);
+    builder = lancedb_connect_builder_session(builder, session);
+    REQUIRE(builder != nullptr);
+    LanceDBConnection* db = lancedb_connect_builder_execute(builder);
+    REQUIRE(db != nullptr);
+    lancedb_connection_free(db);
+    lancedb_session_free(session);
+  }
+  SECTION("NULL session on builder should be allowed and use default session") {
+    LanceDBConnectBuilder* builder = lancedb_connect(uri.c_str());
+    REQUIRE(builder != nullptr);
+    builder = lancedb_connect_builder_session(builder, nullptr);
+    REQUIRE(builder != nullptr);
+    LanceDBConnection* db = lancedb_connect_builder_execute(builder);
+    REQUIRE(db != nullptr);
+    lancedb_connection_free(db);
+  }
+}
+
+TEST_CASE_METHOD(BaseFixture, "LanceDB Session", "[connection]") {
+  SECTION("Create and free default session") {
+    LanceDBSession* session = lancedb_session_new(nullptr);
+    REQUIRE(session != nullptr);
+    lancedb_session_free(session);
+  }
+  SECTION("Create session with options") {
+    LanceDBSessionOptions options{};
+    options.index_cache_bytes = 1024 * 1024;
+    options.metadata_cache_bytes = 2 * 1024 * 1024;
+    LanceDBSession* session = lancedb_session_new(&options);
+    REQUIRE(session != nullptr);
+    lancedb_session_free(session);
+  }
+  SECTION("Zero options fallback to defaults") {
+    LanceDBSessionOptions options{};
+    options.index_cache_bytes = 0;
+    options.metadata_cache_bytes = 0;
+    LanceDBSession* session = lancedb_session_new(&options);
+    REQUIRE(session != nullptr);
+    lancedb_session_free(session);
+  }
+  SECTION("Get session cache stats") {
+    LanceDBSession* session = lancedb_session_new(nullptr);
+    REQUIRE(session != nullptr);
+    LanceDBSessionCacheStats index_stats{};
+    LanceDBSessionCacheStats metadata_stats{};
+    char* error_message = nullptr;
+    auto index_result = lancedb_session_index_cache_stats(session, &index_stats, &error_message);
+    REQUIRE(index_result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+    auto metadata_result = lancedb_session_metadata_cache_stats(session, &metadata_stats, &error_message);
+    REQUIRE(metadata_result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+    lancedb_session_free(session);
+  }
+  SECTION("Get session cache stats with invalid args should fail") {
+    LanceDBSession* session = lancedb_session_new(nullptr);
+    REQUIRE(session != nullptr);
+    LanceDBSessionCacheStats stats{};
+    char* error_message = nullptr;
+    auto result = lancedb_session_index_cache_stats(nullptr, &stats, &error_message);
+    REQUIRE(result == LANCEDB_INVALID_ARGUMENT);
+    REQUIRE(error_message != nullptr);
+    lancedb_free_string(error_message);
+    error_message = nullptr;
+    result = lancedb_session_metadata_cache_stats(session, nullptr, &error_message);
+    REQUIRE(result == LANCEDB_INVALID_ARGUMENT);
+    REQUIRE(error_message != nullptr);
+    lancedb_free_string(error_message);
+    lancedb_session_free(session);
   }
   SECTION("Connect failure") {
     // create a regular file at data_dir so that creating the
@@ -412,4 +489,3 @@ TEST_CASE_METHOD(LanceDBFixture, "LanceDB Namespaces", "[connection]") {
     lancedb_free_string(error_message);
   }
 }
-

--- a/tests/test_query.cpp
+++ b/tests/test_query.cpp
@@ -282,3 +282,56 @@ TEST_CASE_METHOD(LanceDBFixture, "LanceDB Query - Where Filter no Index", "[quer
   lancedb_table_free(table);
 }
 
+TEST_CASE_METHOD(LanceDBSessionFixture, "LanceDB Query - repeated queries populate session cache stats", "[query][session]") {
+
+  LanceDBSessionCacheStats initial_index_stats{};
+  LanceDBSessionCacheStats final_index_stats{};
+
+  char* error_message = nullptr;
+  LanceDBError result = lancedb_session_index_cache_stats(session, &initial_index_stats, &error_message);
+  REQUIRE(result == LANCEDB_SUCCESS);
+  REQUIRE(error_message == nullptr);
+
+  REQUIRE(initial_index_stats.hits == 0);
+  REQUIRE(initial_index_stats.misses == 0);
+  REQUIRE(initial_index_stats.num_entries == 0);
+  REQUIRE(initial_index_stats.size_bytes == 0);
+
+  const std::string table_name = "query_session_cache_stats_test";
+  constexpr size_t total_rows = 100;
+  LanceDBTable* table = create_table_with_data(table_name, total_rows, 0);
+  REQUIRE(table != nullptr);
+  create_key_index(table);
+
+  constexpr size_t repeat_count = 20;
+  const char* columns[] = {"key", "data"};
+  for (size_t i = 0; i < repeat_count; i++) {
+    LanceDBQuery* query = lancedb_query_new(table);
+    REQUIRE(query != nullptr);
+
+    const std::string filter = "key = \"key_" + std::to_string(i % total_rows) + "\"";
+    result = lancedb_query_where_filter(query, filter.c_str(), &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    result = lancedb_query_select(query, columns, 2, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    LanceDBQueryResult* query_result = lancedb_query_execute(query);
+    REQUIRE(query_result != nullptr);
+    lancedb_query_result_free(query_result);
+  }
+
+  result = lancedb_session_index_cache_stats(session, &final_index_stats, &error_message);
+  REQUIRE(result == LANCEDB_SUCCESS);
+  REQUIRE(error_message == nullptr);
+
+  REQUIRE(final_index_stats.hits > initial_index_stats.hits);
+  REQUIRE(final_index_stats.misses > initial_index_stats.misses);
+  REQUIRE(final_index_stats.num_entries > initial_index_stats.num_entries);
+  REQUIRE(final_index_stats.size_bytes > initial_index_stats.size_bytes);
+  REQUIRE(final_index_stats.hits > final_index_stats.misses);
+  
+  lancedb_table_free(table);
+}

--- a/tests/test_table.cpp
+++ b/tests/test_table.cpp
@@ -658,3 +658,48 @@ TEST_CASE_METHOD(LanceDBFixture, "LanceDB Create Reader", "[table]") {
     }
   }
 }
+TEST_CASE_METHOD(LanceDBSessionFixture, "LanceDB Table CRUD with same session across multiple tables", "[table][session]") {
+  const char* _namespace = nullptr;
+  const std::string table_a_name = "session_table_a";
+  const std::string table_b_name = "session_table_b";
+  constexpr auto table_a_rows = 10;
+  constexpr auto table_b_rows = 15;
+
+  // Create
+  LanceDBTable* table_a = create_table_with_data(table_a_name, table_a_rows, 0);
+  LanceDBTable* table_b = create_table_with_data(table_b_name, table_b_rows, 0);
+  REQUIRE(table_a != nullptr);
+  REQUIRE(table_b != nullptr);
+
+  // Read after create
+  REQUIRE(lancedb_table_count_rows(table_a) == table_a_rows);
+  REQUIRE(lancedb_table_count_rows(table_b) == table_b_rows);
+
+  // Reopen and read again
+  lancedb_table_free(table_a);
+  lancedb_table_free(table_b);
+  table_a = lancedb_connection_open_table(db, table_a_name.c_str());
+  table_b = lancedb_connection_open_table(db, table_b_name.c_str());
+  REQUIRE(table_a != nullptr);
+  REQUIRE(table_b != nullptr);
+  REQUIRE(lancedb_table_count_rows(table_a) == table_a_rows);
+  REQUIRE(lancedb_table_count_rows(table_b) == table_b_rows);
+
+  // Delete
+  lancedb_table_free(table_a);
+  lancedb_table_free(table_b);
+  char* error_message = nullptr;
+  LanceDBError result = lancedb_connection_drop_table(db, table_a_name.c_str(), _namespace, &error_message);
+  REQUIRE(result == LANCEDB_SUCCESS);
+  REQUIRE(error_message == nullptr);
+
+  result = lancedb_connection_drop_table(db, table_b_name.c_str(), _namespace, &error_message);
+  REQUIRE(result == LANCEDB_SUCCESS);
+  REQUIRE(error_message == nullptr);
+
+  // Verify delete
+  table_a = lancedb_connection_open_table(db, table_a_name.c_str());
+  table_b = lancedb_connection_open_table(db, table_b_name.c_str());
+  REQUIRE(table_a == nullptr);
+  REQUIRE(table_b == nullptr);
+}

--- a/tests/test_vector_query.cpp
+++ b/tests/test_vector_query.cpp
@@ -20,6 +20,19 @@ static std::vector<float> generate_random_query_vector(size_t dimensions) {
   return query_vector;
 }
 
+// Helper function to generate deterministic query vector for a fixed seed
+static std::vector<float> generate_random_query_vector(size_t dimensions, uint32_t seed) {
+  std::vector<float> query_vector(dimensions);
+  std::mt19937 gen(seed);
+  std::uniform_real_distribution<float> dis(0.0f, 10.0f);
+
+  for (size_t i = 0; i < dimensions; i++) {
+    query_vector[i] = dis(gen);
+  }
+
+  return query_vector;
+}
+
 TEST_CASE_METHOD(LanceDBFixture, "LanceDB Vector Query - nearest_to without index", "[vector_query]") {
   const std::string table_name = "vector_query_test";
   constexpr size_t total_rows = 100;
@@ -811,3 +824,66 @@ TEST_CASE_METHOD(LanceDBFixture, "LanceDB Vector Query - error cases", "[vector_
   lancedb_table_free(table);
 }
 
+TEST_CASE_METHOD(LanceDBSessionFixture, "LanceDB Vector Query - repeated queries populate session cache stats", "[vector_query][session]") {
+  LanceDBSessionCacheStats initial_index_stats{};
+  LanceDBSessionCacheStats final_index_stats{};
+  char* error_message = nullptr;
+
+  LanceDBError result = lancedb_session_index_cache_stats(session, &initial_index_stats, &error_message);
+  REQUIRE(result == LANCEDB_SUCCESS);
+  REQUIRE(error_message == nullptr);
+
+  const std::string table_name = "vector_query_session_cache_stats_test";
+  constexpr size_t total_rows = 256;
+  LanceDBTable* table = create_table_with_data(table_name, total_rows, 0);
+  REQUIRE(table != nullptr);
+
+  const char* vector_columns[] = {"data"};
+  LanceDBVectorIndexConfig config = {
+    .num_partitions = 4,
+    .num_sub_vectors = -1,
+    .max_iterations = -1,
+    .sample_rate = 0.0f,
+    .distance_type = LANCEDB_DISTANCE_L2,
+    .accelerator = nullptr,
+    .replace = 0
+  };
+
+  result = lancedb_table_create_vector_index(
+      table, vector_columns, 1, LANCEDB_INDEX_IVF_FLAT, &config, &error_message);
+  REQUIRE(result == LANCEDB_SUCCESS);
+  REQUIRE(error_message == nullptr);
+
+  
+  constexpr size_t repeat_count = 20;
+  constexpr size_t limit = 10;
+  for (size_t i = 0; i < repeat_count; i++) {
+    uint32_t query_seed = static_cast<uint32_t>(i);
+    std::vector<float> query_vector = generate_random_query_vector(TEST_SCHEMA_DIMENSIONS, query_seed);
+    LanceDBVectorQuery* query = lancedb_vector_query_new(
+        table,
+        query_vector.data(),
+        TEST_SCHEMA_DIMENSIONS);
+    REQUIRE(query != nullptr);
+
+    result = lancedb_vector_query_limit(query, limit, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    LanceDBQueryResult* query_result = lancedb_vector_query_execute(query);
+    REQUIRE(query_result != nullptr);
+    lancedb_query_result_free(query_result);
+  }
+
+  result = lancedb_session_index_cache_stats(session, &final_index_stats, &error_message);
+  REQUIRE(result == LANCEDB_SUCCESS);
+  REQUIRE(error_message == nullptr);
+
+  REQUIRE(final_index_stats.hits > initial_index_stats.hits);
+  REQUIRE(final_index_stats.misses > initial_index_stats.misses);
+  REQUIRE(final_index_stats.num_entries > initial_index_stats.num_entries);
+  REQUIRE(final_index_stats.size_bytes > initial_index_stats.size_bytes);
+  REQUIRE(final_index_stats.hits > final_index_stats.misses);
+
+  lancedb_table_free(table);
+}


### PR DESCRIPTION
This PR addresses https://github.com/lancedb/lancedb-c/issues/17. 

What's been implemented?

- Added session FFI types and APIs in Rust under `src/connection.rs`.
- Added matching public C API declarations under `include/lancedb.h`.
- Added coverage tests for session C API under `tests/test_connection.cpp`, `tests/test_table.cpp` and `tests/test_query.cpp`, `tests/test_vector_query.cpp`.
- Added docs under `docs/index.rst`.

To-Discuss and Pending Items: 
- Object Store Registry - how to go about implementing this interface? Current implementations initiates session with default Object Store Registry, no registry API exposed. (This is deferred for the time being as per our discussion last week).