### PR TITLE
Adds the LanceDBIndexStats struct and the lancedb_table_index_stats() C API declaration

### DIFF
--- a/include/lancedb.h
+++ b/include/lancedb.h
@@ -1242,6 +1242,35 @@ LanceDBError lancedb_table_optimize(
 void lancedb_free_index_list(char** indices, size_t count);
 
 /**
+ * Index statistics structure
+ */
+typedef struct {
+    size_t num_indexed_rows;     // Rows covered by the index
+    size_t num_unindexed_rows;   // Rows not yet indexed
+    unsigned int num_indices;    // Number of index parts (0 if unknown)
+} LanceDBIndexStats;
+
+/**
+ * Get statistics for a named index on the table
+ *
+ * @param table - pointer to LanceDBTable
+ * @param index_name - null-terminated C string containing the index name
+ * @param stats_out - pointer to receive the index statistics
+ * @param error_message - optional pointer to receive detailed error message (NULL to ignore)
+ * @return LANCEDB_SUCCESS if stats retrieved, LANCEDB_INDEX_NOT_FOUND if index doesn't exist
+ *
+ * The stats are read directly from the LanceDB manifest (no external state needed).
+ * If error_message is provided and an error occurs, the caller must free
+ * the error message with lancedb_free_string().
+ */
+LanceDBError lancedb_table_index_stats(
+    const LanceDBTable* table,
+    const char* index_name,
+    LanceDBIndexStats* stats_out,
+    char** error_message
+);
+
+/**
  * Free Arrow arrays returned by vector search functions
  *
  * @param arrays - array of Arrow C ABI array pointers

--- a/src/index.rs
+++ b/src/index.rs
@@ -612,3 +612,59 @@ pub unsafe extern "C" fn lancedb_free_index_list(indices: *mut *mut c_char, coun
         libc::free(indices as *mut libc::c_void);
     }
 }
+
+/// Index statistics returned by lancedb_table_index_stats
+#[repr(C)]
+#[derive(Debug)]
+pub struct LanceDBIndexStats {
+    pub num_indexed_rows: usize,
+    pub num_unindexed_rows: usize,
+    pub num_indices: u32,
+}
+
+/// Get statistics for a named index on the table
+///
+/// # Safety
+/// - `table` must be a valid pointer returned from `lancedb_connection_open_table`
+/// - `index_name` must be a valid null-terminated C string
+/// - `stats_out` must be a valid pointer to receive the statistics
+/// - `error_message` can be NULL to ignore detailed error messages
+///
+/// # Returns
+/// - `LANCEDB_SUCCESS` if stats were retrieved
+/// - `LANCEDB_INDEX_NOT_FOUND` if the index does not exist
+/// - Other error codes on failure
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_table_index_stats(
+    table: *const LanceDBTable,
+    index_name: *const c_char,
+    stats_out: *mut LanceDBIndexStats,
+    error_message: *mut *mut c_char,
+) -> LanceDBError {
+    if table.is_null() || index_name.is_null() || stats_out.is_null() {
+        set_invalid_argument_message(error_message);
+        return LanceDBError::InvalidArgument;
+    }
+
+    let Ok(name_str) = CStr::from_ptr(index_name).to_str() else {
+        set_invalid_argument_message(error_message);
+        return LanceDBError::InvalidArgument;
+    };
+
+    let tbl = &(*table).inner;
+    let runtime = get_runtime();
+
+    match runtime.block_on(tbl.index_stats(name_str)) {
+        Ok(Some(stats)) => {
+            (*stats_out).num_indexed_rows = stats.num_indexed_rows;
+            (*stats_out).num_unindexed_rows = stats.num_unindexed_rows;
+            (*stats_out).num_indices = stats.num_indices.unwrap_or(0);
+            LanceDBError::Success
+        }
+        Ok(None) => {
+            // Index not found
+            LanceDBError::IndexNotFound
+        }
+        Err(e) => handle_error(&e, error_message),
+    }
+}

--- a/tests/test_index.cpp
+++ b/tests/test_index.cpp
@@ -161,6 +161,130 @@ TEST_CASE_METHOD(LanceDBFixture, "LanceDB Scalar Index", "[index]") {
   }
 }
 
+TEST_CASE_METHOD(LanceDBFixture, "LanceDB Index Stats", "[index]") {
+  const std::string table_name = "index_stats_test";
+
+  SECTION("Get stats for a scalar index") {
+    // Create table with data and a BTREE index
+    LanceDBTable* table = create_table_with_data(table_name, 100, 0);
+    REQUIRE(table != nullptr);
+
+    const char* columns[] = {"key"};
+    LanceDBScalarIndexConfig config = {
+      .replace = 0,
+      .force_update_statistics = 0
+    };
+
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_table_create_scalar_index(
+        table, columns, 1, LANCEDB_INDEX_BTREE, &config, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+
+    // Get the index name
+    char** indices = nullptr;
+    size_t count = 0;
+    result = lancedb_table_list_indices(table, &indices, &count, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(count == 1);
+    std::string index_name = indices[0];
+    lancedb_free_index_list(indices, count);
+
+    // Get index stats
+    LanceDBIndexStats stats = {};
+    result = lancedb_table_index_stats(table, index_name.c_str(), &stats, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    INFO("Indexed rows: " << stats.num_indexed_rows);
+    INFO("Unindexed rows: " << stats.num_unindexed_rows);
+    INFO("Num indices: " << stats.num_indices);
+
+    // After creating the index, all rows should be indexed
+    REQUIRE(stats.num_indexed_rows == 100);
+    REQUIRE(stats.num_unindexed_rows == 0);
+
+    lancedb_table_free(table);
+  }
+
+  SECTION("Stats reflect unindexed rows after adding data") {
+    // Create table with data and a BTREE index
+    LanceDBTable* table = create_table_with_data(table_name, 100, 0);
+    REQUIRE(table != nullptr);
+
+    const char* columns[] = {"key"};
+    LanceDBScalarIndexConfig config = {
+      .replace = 0,
+      .force_update_statistics = 0
+    };
+
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_table_create_scalar_index(
+        table, columns, 1, LANCEDB_INDEX_BTREE, &config, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+
+    // Get the index name
+    char** indices = nullptr;
+    size_t count = 0;
+    result = lancedb_table_list_indices(table, &indices, &count, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(count == 1);
+    std::string index_name = indices[0];
+    lancedb_free_index_list(indices, count);
+
+    // Add more data (these rows won't be indexed yet)
+    auto batch = create_test_record_batch(50, 100);
+    auto reader = create_reader_from_batch(batch);
+    REQUIRE(reader != nullptr);
+    result = lancedb_table_add(table, reader, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+
+    // Get index stats - should show unindexed rows
+    LanceDBIndexStats stats = {};
+    result = lancedb_table_index_stats(table, index_name.c_str(), &stats, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    INFO("Indexed rows: " << stats.num_indexed_rows);
+    INFO("Unindexed rows: " << stats.num_unindexed_rows);
+
+    REQUIRE(stats.num_indexed_rows == 100);
+    REQUIRE(stats.num_unindexed_rows == 50);
+
+    lancedb_table_free(table);
+  }
+
+  SECTION("Stats for non-existent index returns INDEX_NOT_FOUND") {
+    LanceDBTable* table = create_table_with_data(table_name, 100, 0);
+    REQUIRE(table != nullptr);
+
+    LanceDBIndexStats stats = {};
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_table_index_stats(
+        table, "no_such_index", &stats, &error_message);
+
+    REQUIRE(result == LANCEDB_INDEX_NOT_FOUND);
+
+    if (error_message) {
+      lancedb_free_string(error_message);
+    }
+
+    lancedb_table_free(table);
+  }
+
+  SECTION("Stats with null table returns INVALID_ARGUMENT") {
+    LanceDBIndexStats stats = {};
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_table_index_stats(
+        nullptr, "some_index", &stats, &error_message);
+
+    REQUIRE(result == LANCEDB_INVALID_ARGUMENT);
+
+    if (error_message) {
+      lancedb_free_string(error_message);
+    }
+  }
+}
+
 TEST_CASE_METHOD(LanceDBFixture, "LanceDB Scalar Index List and Drop", "[index]") {
   const std::string table_name = "index_list_drop_test";
 


### PR DESCRIPTION
Adds the LanceDBIndexStats struct and the lancedb_table_index_stats() C API declaration. The struct exposes num_indexed_rows, num_unindexed_rows, and num_indices. The function retrieves index statistics for a named index directly from the LanceDB manifest. (that information is required for the index-rebuild)