### PR TITLE
add datafusion as an alternative to SQL with queries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,6 +399,30 @@ if(BUILD_TESTS)
   )
   list(APPEND TEST_TARGETS lancedb_query_tests)
 
+  # Add test executable for DataFusion expression query tests
+  add_executable(lancedb_df_query_tests
+    tests/test_main.cpp
+    tests/test_common.cpp
+    tests/test_df_query.cpp
+  )
+  target_link_libraries(lancedb_df_query_tests
+    PRIVATE
+    lancedb
+    Catch2::Catch2
+    Threads::Threads
+    ${ARROW_LIBRARIES}
+  )
+  target_include_directories(lancedb_df_query_tests
+    PRIVATE ${ARROW_INCLUDE_DIRS}
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests
+  )
+  target_compile_options(lancedb_df_query_tests PRIVATE ${ARROW_CFLAGS_OTHER})
+  set_target_properties(lancedb_df_query_tests PROPERTIES
+    BUILD_RPATH ${RUST_TARGET_DIR}
+  )
+  list(APPEND TEST_TARGETS lancedb_df_query_tests)
+
   # Add test executable for vector query tests (runs without valgrind)
   add_executable(lancedb_vector_query_tests
     tests/test_main.cpp
@@ -503,6 +527,19 @@ if(BUILD_TESTS)
         --suppressions=${CMAKE_CURRENT_SOURCE_DIR}/valgrind.supp
         $<TARGET_FILE:lancedb_query_tests>
     )
+    # Run DataFusion expression query tests with valgrind
+    add_test(NAME lancedb_df_query_tests
+      COMMAND ${TEST_ENV_PREFIX} ${VALGRIND_EXECUTABLE}
+        --tool=memcheck
+        --leak-check=full
+        --show-leak-kinds=definite
+        --errors-for-leak-kinds=definite
+        --track-origins=yes
+        --error-exitcode=1
+        --log-file=${CMAKE_BINARY_DIR}/valgrind_df_query.txt
+        --suppressions=${CMAKE_CURRENT_SOURCE_DIR}/valgrind.supp
+        $<TARGET_FILE:lancedb_df_query_tests>
+    )
   else()
     message(WARNING "Valgrind not found, running tests without memory checking")
     add_test(NAME lancedb_connection_tests COMMAND ${TEST_ENV_PREFIX} $<TARGET_FILE:lancedb_connection_tests>)
@@ -510,6 +547,7 @@ if(BUILD_TESTS)
     add_test(NAME lancedb_table_meta_tests COMMAND ${TEST_ENV_PREFIX} $<TARGET_FILE:lancedb_table_meta_tests>)
     add_test(NAME lancedb_index_tests COMMAND ${TEST_ENV_PREFIX} $<TARGET_FILE:lancedb_index_tests>)
     add_test(NAME lancedb_query_tests COMMAND ${TEST_ENV_PREFIX} $<TARGET_FILE:lancedb_query_tests>)
+    add_test(NAME lancedb_df_query_tests COMMAND ${TEST_ENV_PREFIX} $<TARGET_FILE:lancedb_df_query_tests>)
   endif()
 
   # Run vector index tests WITHOUT valgrind (too slow under valgrind)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3604,6 +3604,7 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "chrono",
+ "datafusion-expr",
  "futures",
  "lance",
  "lancedb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,6 @@ arrow = { version = "56.2", optional = false }
 arrow-array = "56.2"
 arrow-data = "56.2"
 arrow-schema = "56.2"
+datafusion-expr = "50.1"
 futures = "0"
 chrono = "0"

--- a/include/lancedb.h
+++ b/include/lancedb.h
@@ -9,6 +9,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,6 +34,11 @@ typedef struct LanceDBTable LanceDBTable;
  * Opaque handle to a LanceDB TableNamesBuilder
  */
 typedef struct LanceDBTableNamesBuilder LanceDBTableNamesBuilder;
+
+/**
+ * Opaque handle to a DataFusion Expr (for building filter expressions)
+ */
+typedef struct LanceDBExpr LanceDBExpr;
 
 /**
  * Opaque handle to a LanceDB Query
@@ -175,6 +181,25 @@ typedef enum {
     LANCEDB_OPTIMIZE_PRUNE = 2,   // Only prune old versions
     LANCEDB_OPTIMIZE_INDEX = 3    // Only rebuild indices
 } LanceDBOptimizeType;
+
+/**
+ * Binary operator enum for DataFusion expressions
+ */
+typedef enum {
+    LANCEDB_BINARY_OP_EQ = 0,
+    LANCEDB_BINARY_OP_NOT_EQ = 1,
+    LANCEDB_BINARY_OP_LT = 2,
+    LANCEDB_BINARY_OP_LT_EQ = 3,
+    LANCEDB_BINARY_OP_GT = 4,
+    LANCEDB_BINARY_OP_GT_EQ = 5,
+    LANCEDB_BINARY_OP_AND = 6,
+    LANCEDB_BINARY_OP_OR = 7,
+    LANCEDB_BINARY_OP_PLUS = 8,
+    LANCEDB_BINARY_OP_MINUS = 9,
+    LANCEDB_BINARY_OP_MULTIPLY = 10,
+    LANCEDB_BINARY_OP_DIVIDE = 11,
+    LANCEDB_BINARY_OP_MODULO = 12
+} LanceDBBinaryOp;
 
 /**
  * Vector index configuration
@@ -843,6 +868,9 @@ LanceDBError lancedb_query_select(
 /**
  * Set WHERE filter for query
  *
+ * If both a SQL WHERE clause and a DataFusion filters are set, the DataFusion expression
+ * takes precedence.
+ *
  * @param query - pointer to LanceDBQuery
  * @param filter - SQL WHERE clause string
  * @param error_message - optional pointer to receive detailed error message (NULL to ignore)
@@ -854,6 +882,23 @@ LanceDBError lancedb_query_select(
 LanceDBError lancedb_query_where_filter(
     LanceDBQuery* query,
     const char* filter,
+    char** error_message
+);
+
+/**
+ * Set DataFusion Expr filter for query
+ *
+ * If both a DataFusion and a SQL WHERE clause filters are set, the DataFusion expression
+ * takes precedence.
+ *
+ * @param query - pointer to LanceDBQuery
+ * @param expr - pointer to LanceDBExpr (consumed by this function; do not use or free after calling)
+ * @param error_message - optional pointer to receive detailed error message (NULL to ignore)
+ * @return Error code indicating success or failure
+ */
+LanceDBError lancedb_query_df_filter(
+    LanceDBQuery* query,
+    LanceDBExpr* expr,
     char** error_message
 );
 
@@ -930,6 +975,9 @@ LanceDBError lancedb_vector_query_select(
 /**
  * Set WHERE filter for vector query
  *
+ * If both a SQL WHERE clause and a DataFusion filters are set, the DataFusion expression
+ * takes precedence.
+ *
  * @param query - pointer to LanceDBVectorQuery
  * @param filter - SQL WHERE clause string
  * @param error_message - optional pointer to receive detailed error message (NULL to ignore)
@@ -941,6 +989,23 @@ LanceDBError lancedb_vector_query_select(
 LanceDBError lancedb_vector_query_where_filter(
     LanceDBVectorQuery* query,
     const char* filter,
+    char** error_message
+);
+
+/**
+ * Set DataFusion Expr filter for vector query
+ *
+ * If both a DataFusion and a SQL WHERE clause filters are set, the DataFusion expression
+ * takes precedence.
+ *
+ * @param query - pointer to LanceDBVectorQuery
+ * @param expr - pointer to LanceDBExpr (consumed by this function; do not use or free after calling)
+ * @param error_message - optional pointer to receive detailed error message (NULL to ignore)
+ * @return Error code indicating success or failure
+ */
+LanceDBError lancedb_vector_query_df_filter(
+    LanceDBVectorQuery* query,
+    LanceDBExpr* expr,
     char** error_message
 );
 
@@ -1505,6 +1570,160 @@ void lancedb_free_metadata(char** keys, char** values, size_t count);
  * @param str - string pointer returned by LanceDB functions
  */
 void lancedb_free_string(char* str);
+
+/* ==================== DataFusion Expression Builder API ==================== */
+
+/**
+ * Create a column reference expression
+ *
+ * @param name - null-terminated C string containing the column name
+ * @return Non-null pointer to LanceDBExpr on success, NULL on failure
+ *         Caller must free with lancedb_expr_free()
+ */
+LanceDBExpr* lancedb_expr_column(const char* name);
+
+/**
+ * Create a string literal expression
+ *
+ * @param value - null-terminated C string containing the literal value
+ * @return Non-null pointer to LanceDBExpr on success, NULL on failure
+ *         Caller must free with lancedb_expr_free()
+ */
+LanceDBExpr* lancedb_expr_literal_string(const char* value);
+
+/**
+ * Create an integer literal expression (i64)
+ *
+ * @param value - the integer value
+ * @return Non-null pointer to LanceDBExpr
+ *         Caller must free with lancedb_expr_free()
+ */
+LanceDBExpr* lancedb_expr_literal_i64(int64_t value);
+
+/**
+ * Create a float literal expression (f64)
+ *
+ * @param value - the float value
+ * @return Non-null pointer to LanceDBExpr
+ *         Caller must free with lancedb_expr_free()
+ */
+LanceDBExpr* lancedb_expr_literal_f64(double value);
+
+/**
+ * Create a boolean literal expression
+ *
+ * @param value - the boolean value
+ * @return Non-null pointer to LanceDBExpr
+ *         Caller must free with lancedb_expr_free()
+ */
+LanceDBExpr* lancedb_expr_literal_bool(bool value);
+
+/**
+ * Create a binary expression (left op right)
+ *
+ * @param left - pointer to LanceDBExpr for left operand (consumed)
+ * @param op - binary operator
+ * @param right - pointer to LanceDBExpr for right operand (consumed)
+ * @return Non-null pointer to LanceDBExpr on success, NULL on failure
+ *         Both left and right are consumed; do not use or free them after calling
+ *         Caller must free result with lancedb_expr_free()
+ */
+LanceDBExpr* lancedb_expr_binary(
+    LanceDBExpr* left,
+    LanceDBBinaryOp op,
+    LanceDBExpr* right
+);
+
+/**
+ * Create a NOT expression
+ *
+ * @param expr - pointer to LanceDBExpr (consumed)
+ * @return Non-null pointer to LanceDBExpr on success, NULL on failure
+ *         The input expr is consumed; do not use or free it after calling
+ *         Caller must free result with lancedb_expr_free()
+ */
+LanceDBExpr* lancedb_expr_not(LanceDBExpr* expr);
+
+/**
+ * Create an IS NULL expression
+ *
+ * @param expr - pointer to LanceDBExpr (consumed)
+ * @return Non-null pointer to LanceDBExpr on success, NULL on failure
+ *         The input expr is consumed; do not use or free it after calling
+ *         Caller must free result with lancedb_expr_free()
+ */
+LanceDBExpr* lancedb_expr_is_null(LanceDBExpr* expr);
+
+/**
+ * Create an IS NOT NULL expression
+ *
+ * @param expr - pointer to LanceDBExpr (consumed)
+ * @return Non-null pointer to LanceDBExpr on success, NULL on failure
+ *         The input expr is consumed; do not use or free it after calling
+ *         Caller must free result with lancedb_expr_free()
+ */
+LanceDBExpr* lancedb_expr_is_not_null(LanceDBExpr* expr);
+
+/**
+ * Create an AND expression (convenience for binary AND)
+ *
+ * @param left - pointer to LanceDBExpr (consumed)
+ * @param right - pointer to LanceDBExpr (consumed)
+ * @return Non-null pointer to LanceDBExpr on success, NULL on failure
+ *         Both inputs are consumed; do not use or free them after calling
+ *         Caller must free result with lancedb_expr_free()
+ */
+LanceDBExpr* lancedb_expr_and(LanceDBExpr* left, LanceDBExpr* right);
+
+/**
+ * Create an OR expression (convenience for binary OR)
+ *
+ * @param left - pointer to LanceDBExpr (consumed)
+ * @param right - pointer to LanceDBExpr (consumed)
+ * @return Non-null pointer to LanceDBExpr on success, NULL on failure
+ *         Both inputs are consumed; do not use or free them after calling
+ *         Caller must free result with lancedb_expr_free()
+ */
+LanceDBExpr* lancedb_expr_or(LanceDBExpr* left, LanceDBExpr* right);
+
+/**
+ * Create an IN list expression (expr IN (value1, value2, ...))
+ *
+ * @param expr - pointer to LanceDBExpr for the expression to check (consumed)
+ * @param list - array of pointers to LanceDBExpr for list values (all consumed)
+ * @param list_len - number of elements in the list
+ * @param negated - if true, creates NOT IN instead of IN
+ * @param error_message - optional pointer to receive detailed error message (NULL to ignore)
+ * @return Non-null pointer to LanceDBExpr on success, NULL on failure
+ *         The input expr and all list elements are consumed; do not use or free them after calling
+ *         Caller must free result with lancedb_expr_free()
+ */
+LanceDBExpr* lancedb_expr_in_list(
+    LanceDBExpr* expr,
+    LanceDBExpr* const* list,
+    size_t list_len,
+    bool negated,
+    char** error_message
+);
+
+/**
+ * Clone an expression (creates an independent copy)
+ *
+ * @param expr - pointer to LanceDBExpr to clone (not consumed)
+ * @return Non-null pointer to a new LanceDBExpr on success, NULL on failure
+ *         The original expr remains valid and must still be freed separately
+ *         Caller must free result with lancedb_expr_free()
+ */
+LanceDBExpr* lancedb_expr_clone(const LanceDBExpr* expr);
+
+/**
+ * Free an expression
+ *
+ * @param expr - pointer to LanceDBExpr
+ *
+ * After calling this function, the expr pointer must not be used.
+ */
+void lancedb_expr_free(LanceDBExpr* expr);
 
 #ifdef __cplusplus
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1,0 +1,380 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+//! DataFusion Expr C API for building filter expressions
+//!
+//! This module provides C-callable functions to construct DataFusion `Expr` values
+//! that can be used as query filters via `lancedb_query_df_filter()`.
+
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+use datafusion_expr::expr::BinaryExpr;
+use datafusion_expr::{col, lit, Expr, Operator};
+
+use crate::error::set_invalid_argument_message;
+
+/// Opaque handle to a DataFusion Expr
+pub struct LanceDBExpr {
+    pub(crate) inner: Expr,
+}
+
+/// Binary operator enum for C API
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub enum LanceDBBinaryOp {
+    Eq = 0,
+    NotEq = 1,
+    Lt = 2,
+    LtEq = 3,
+    Gt = 4,
+    GtEq = 5,
+    And = 6,
+    Or = 7,
+    Plus = 8,
+    Minus = 9,
+    Multiply = 10,
+    Divide = 11,
+    Modulo = 12,
+}
+
+impl From<LanceDBBinaryOp> for Operator {
+    fn from(op: LanceDBBinaryOp) -> Self {
+        match op {
+            LanceDBBinaryOp::Eq => Operator::Eq,
+            LanceDBBinaryOp::NotEq => Operator::NotEq,
+            LanceDBBinaryOp::Lt => Operator::Lt,
+            LanceDBBinaryOp::LtEq => Operator::LtEq,
+            LanceDBBinaryOp::Gt => Operator::Gt,
+            LanceDBBinaryOp::GtEq => Operator::GtEq,
+            LanceDBBinaryOp::And => Operator::And,
+            LanceDBBinaryOp::Or => Operator::Or,
+            LanceDBBinaryOp::Plus => Operator::Plus,
+            LanceDBBinaryOp::Minus => Operator::Minus,
+            LanceDBBinaryOp::Multiply => Operator::Multiply,
+            LanceDBBinaryOp::Divide => Operator::Divide,
+            LanceDBBinaryOp::Modulo => Operator::Modulo,
+        }
+    }
+}
+
+/// Create a column reference expression
+///
+/// # Safety
+/// - `name` must be a valid null-terminated C string
+///
+/// # Returns
+/// - Non-null pointer to LanceDBExpr on success, NULL on failure
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_expr_column(name: *const c_char) -> *mut LanceDBExpr {
+    if name.is_null() {
+        return std::ptr::null_mut();
+    }
+
+    let name_str = match CStr::from_ptr(name).to_str() {
+        Ok(s) => s,
+        Err(_) => return std::ptr::null_mut(),
+    };
+
+    Box::into_raw(Box::new(LanceDBExpr {
+        inner: col(name_str),
+    }))
+}
+
+/// Create a string literal expression
+///
+/// # Safety
+/// - `value` must be a valid null-terminated C string
+///
+/// # Returns
+/// - Non-null pointer to LanceDBExpr on success, NULL on failure
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_expr_literal_string(value: *const c_char) -> *mut LanceDBExpr {
+    if value.is_null() {
+        return std::ptr::null_mut();
+    }
+
+    let value_str = match CStr::from_ptr(value).to_str() {
+        Ok(s) => s.to_string(),
+        Err(_) => return std::ptr::null_mut(),
+    };
+
+    Box::into_raw(Box::new(LanceDBExpr {
+        inner: lit(value_str),
+    }))
+}
+
+/// Create an integer literal expression (i64)
+///
+/// # Returns
+/// - Non-null pointer to LanceDBExpr
+#[no_mangle]
+pub extern "C" fn lancedb_expr_literal_i64(value: i64) -> *mut LanceDBExpr {
+    Box::into_raw(Box::new(LanceDBExpr { inner: lit(value) }))
+}
+
+/// Create a float literal expression (f64)
+///
+/// # Returns
+/// - Non-null pointer to LanceDBExpr
+#[no_mangle]
+pub extern "C" fn lancedb_expr_literal_f64(value: f64) -> *mut LanceDBExpr {
+    Box::into_raw(Box::new(LanceDBExpr { inner: lit(value) }))
+}
+
+/// Create a boolean literal expression
+///
+/// # Returns
+/// - Non-null pointer to LanceDBExpr
+#[no_mangle]
+pub extern "C" fn lancedb_expr_literal_bool(value: bool) -> *mut LanceDBExpr {
+    Box::into_raw(Box::new(LanceDBExpr { inner: lit(value) }))
+}
+
+/// Create a binary expression (left op right)
+///
+/// # Safety
+/// - `left` and `right` must be valid pointers returned from lancedb_expr_* functions
+/// - Both `left` and `right` are consumed by this function; do not use or free them after calling
+///
+/// # Returns
+/// - Non-null pointer to LanceDBExpr on success, NULL on failure
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_expr_binary(
+    left: *mut LanceDBExpr,
+    op: LanceDBBinaryOp,
+    right: *mut LanceDBExpr,
+) -> *mut LanceDBExpr {
+    let left_expr = if !left.is_null() {
+        Some(Box::from_raw(left).inner)
+    } else {
+        None
+    };
+    let right_expr = if !right.is_null() {
+        Some(Box::from_raw(right).inner)
+    } else {
+        None
+    };
+
+    let (Some(left_expr), Some(right_expr)) = (left_expr, right_expr) else {
+        return std::ptr::null_mut();
+    };
+
+    Box::into_raw(Box::new(LanceDBExpr {
+        inner: Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(left_expr),
+            op.into(),
+            Box::new(right_expr),
+        )),
+    }))
+}
+
+/// Create a NOT expression
+///
+/// # Safety
+/// - `expr` must be a valid pointer returned from lancedb_expr_* functions
+/// - `expr` is consumed by this function; do not use or free it after calling
+///
+/// # Returns
+/// - Non-null pointer to LanceDBExpr on success, NULL on failure
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_expr_not(expr: *mut LanceDBExpr) -> *mut LanceDBExpr {
+    if expr.is_null() {
+        return std::ptr::null_mut();
+    }
+
+    let inner = Box::from_raw(expr).inner;
+
+    Box::into_raw(Box::new(LanceDBExpr {
+        inner: Expr::Not(Box::new(inner)),
+    }))
+}
+
+/// Create an IS NULL expression
+///
+/// # Safety
+/// - `expr` must be a valid pointer returned from lancedb_expr_* functions
+/// - `expr` is consumed by this function; do not use or free it after calling
+///
+/// # Returns
+/// - Non-null pointer to LanceDBExpr on success, NULL on failure
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_expr_is_null(expr: *mut LanceDBExpr) -> *mut LanceDBExpr {
+    if expr.is_null() {
+        return std::ptr::null_mut();
+    }
+
+    let inner = Box::from_raw(expr).inner;
+
+    Box::into_raw(Box::new(LanceDBExpr {
+        inner: Expr::IsNull(Box::new(inner)),
+    }))
+}
+
+/// Create an IS NOT NULL expression
+///
+/// # Safety
+/// - `expr` must be a valid pointer returned from lancedb_expr_* functions
+/// - `expr` is consumed by this function; do not use or free it after calling
+///
+/// # Returns
+/// - Non-null pointer to LanceDBExpr on success, NULL on failure
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_expr_is_not_null(expr: *mut LanceDBExpr) -> *mut LanceDBExpr {
+    if expr.is_null() {
+        return std::ptr::null_mut();
+    }
+
+    let inner = Box::from_raw(expr).inner;
+
+    Box::into_raw(Box::new(LanceDBExpr {
+        inner: Expr::IsNotNull(Box::new(inner)),
+    }))
+}
+
+/// Create an AND expression (convenience for binary AND)
+///
+/// # Safety
+/// - `left` and `right` must be valid pointers returned from lancedb_expr_* functions
+/// - Both are consumed by this function; do not use or free them after calling
+///
+/// # Returns
+/// - Non-null pointer to LanceDBExpr on success, NULL on failure
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_expr_and(
+    left: *mut LanceDBExpr,
+    right: *mut LanceDBExpr,
+) -> *mut LanceDBExpr {
+    let left_expr = if !left.is_null() {
+        Some(Box::from_raw(left).inner)
+    } else {
+        None
+    };
+    let right_expr = if !right.is_null() {
+        Some(Box::from_raw(right).inner)
+    } else {
+        None
+    };
+
+    let (Some(left_expr), Some(right_expr)) = (left_expr, right_expr) else {
+        return std::ptr::null_mut();
+    };
+
+    Box::into_raw(Box::new(LanceDBExpr {
+        inner: left_expr.and(right_expr),
+    }))
+}
+
+/// Create an OR expression (convenience for binary OR)
+///
+/// # Safety
+/// - `left` and `right` must be valid pointers returned from lancedb_expr_* functions
+/// - Both are consumed by this function; do not use or free them after calling
+///
+/// # Returns
+/// - Non-null pointer to LanceDBExpr on success, NULL on failure
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_expr_or(
+    left: *mut LanceDBExpr,
+    right: *mut LanceDBExpr,
+) -> *mut LanceDBExpr {
+    let left_expr = if !left.is_null() {
+        Some(Box::from_raw(left).inner)
+    } else {
+        None
+    };
+    let right_expr = if !right.is_null() {
+        Some(Box::from_raw(right).inner)
+    } else {
+        None
+    };
+
+    let (Some(left_expr), Some(right_expr)) = (left_expr, right_expr) else {
+        return std::ptr::null_mut();
+    };
+
+    Box::into_raw(Box::new(LanceDBExpr {
+        inner: left_expr.or(right_expr),
+    }))
+}
+
+/// Create an IN list expression (expr IN (value1, value2, ...))
+///
+/// # Safety
+/// - `expr` must be a valid pointer returned from lancedb_expr_* functions
+/// - `list` must be an array of valid pointers to LanceDBExpr
+/// - `list_len` must match the actual number of elements in the array
+/// - `expr` and all elements of `list` are consumed; do not use or free them after calling
+///
+/// # Returns
+/// - Non-null pointer to LanceDBExpr on success, NULL on failure
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_expr_in_list(
+    expr: *mut LanceDBExpr,
+    list: *const *mut LanceDBExpr,
+    list_len: usize,
+    negated: bool,
+    error_message: *mut *mut c_char,
+) -> *mut LanceDBExpr {
+    if expr.is_null() {
+        set_invalid_argument_message(error_message);
+        return std::ptr::null_mut();
+    }
+
+    let inner = Box::from_raw(expr).inner;
+
+    if list.is_null() {
+        set_invalid_argument_message(error_message);
+        return std::ptr::null_mut();
+    }
+
+    let mut list_exprs = Vec::with_capacity(list_len);
+    let mut has_null = false;
+    for i in 0..list_len {
+        let item = *list.add(i);
+        if !item.is_null() {
+            list_exprs.push(Box::from_raw(item).inner);
+        } else {
+            has_null = true;
+        }
+    }
+    if has_null {
+        set_invalid_argument_message(error_message);
+        return std::ptr::null_mut();
+    }
+
+    Box::into_raw(Box::new(LanceDBExpr {
+        inner: inner.in_list(list_exprs, negated),
+    }))
+}
+
+/// Clone an expression (creates an independent copy)
+///
+/// # Safety
+/// - `expr` must be a valid pointer returned from lancedb_expr_* functions
+/// - The original `expr` remains valid and must still be freed separately
+///
+/// # Returns
+/// - Non-null pointer to a new LanceDBExpr on success, NULL on failure
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_expr_clone(expr: *const LanceDBExpr) -> *mut LanceDBExpr {
+    if expr.is_null() {
+        return std::ptr::null_mut();
+    }
+
+    Box::into_raw(Box::new(LanceDBExpr {
+        inner: (*expr).inner.clone(),
+    }))
+}
+
+/// Free an expression
+///
+/// # Safety
+/// - `expr` must be a valid pointer returned from lancedb_expr_* functions
+/// - `expr` must not be used after calling this function
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_expr_free(expr: *mut LanceDBExpr) {
+    if !expr.is_null() {
+        let _ = Box::from_raw(expr);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod connection;
 pub mod error;
+pub mod expr;
 pub mod index;
 pub mod query;
 pub mod table;
@@ -17,6 +18,7 @@ pub mod types;
 // Re-export all public FFI functions
 pub use connection::*;
 pub use error::*;
+pub use expr::*;
 pub use index::*;
 pub use query::*;
 pub use table::*;

--- a/src/query.rs
+++ b/src/query.rs
@@ -15,11 +15,13 @@ use arrow_array::{Array, RecordBatch, StructArray};
 use arrow_data::ArrayData;
 use futures::TryStreamExt;
 
-use lancedb::query::{ExecutableQuery, QueryBase, Select};
+use datafusion_expr::Expr;
+use lancedb::query::{ExecutableQuery, HasQuery, QueryBase, QueryFilter, Select};
 use lancedb::{DistanceType, Table};
 
 use crate::connection::{get_runtime, LanceDBTable};
 use crate::error::{set_invalid_argument_message, set_unknown_error_message, LanceDBError};
+use crate::expr::LanceDBExpr;
 use crate::types::LanceDBDistanceType;
 
 /// Opaque handle to a LanceDB Query
@@ -30,6 +32,7 @@ pub struct LanceDBQuery {
     offset: Option<usize>,
     select: Option<Select>,
     filter: Option<String>,
+    df_filter: Option<Expr>,
 }
 
 /// Opaque handle to a LanceDB VectorQuery
@@ -42,6 +45,7 @@ pub struct LanceDBVectorQuery {
     offset: Option<usize>,
     select: Option<Select>,
     filter: Option<String>,
+    df_filter: Option<Expr>,
     distance_type: Option<DistanceType>,
     nprobes: Option<usize>,
     refine_factor: Option<u32>,
@@ -76,6 +80,7 @@ pub unsafe extern "C" fn lancedb_query_new(table: *const LanceDBTable) -> *mut L
         offset: None,
         select: None,
         filter: None,
+        df_filter: None,
     });
 
     Box::into_raw(query)
@@ -113,6 +118,7 @@ pub unsafe extern "C" fn lancedb_vector_query_new(
         offset: None,
         select: None,
         filter: None,
+        df_filter: None,
         distance_type: None,
         nprobes: None,
         refine_factor: None,
@@ -233,6 +239,29 @@ pub unsafe extern "C" fn lancedb_query_where_filter(
     };
 
     (*query).filter = Some(filter_str);
+    LanceDBError::Success
+}
+
+/// Set DataFusion Expr filter for query
+///
+/// # Safety
+/// - `query` must be a valid pointer returned from `lancedb_query_new`
+/// - `expr` must be a valid pointer returned from `lancedb_expr_*` functions
+/// - `expr` is consumed by this function; do not use or free it after calling
+/// - `error_message` can be NULL to ignore detailed error messages
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_query_df_filter(
+    query: *mut LanceDBQuery,
+    expr: *mut LanceDBExpr,
+    error_message: *mut *mut c_char,
+) -> LanceDBError {
+    if query.is_null() || expr.is_null() {
+        set_invalid_argument_message(error_message);
+        return LanceDBError::InvalidArgument;
+    }
+
+    let expr_box = Box::from_raw(expr);
+    (*query).df_filter = Some(expr_box.inner);
     LanceDBError::Success
 }
 
@@ -379,6 +408,29 @@ pub unsafe extern "C" fn lancedb_vector_query_where_filter(
     LanceDBError::Success
 }
 
+/// Set DataFusion Expr filter for vector query
+///
+/// # Safety
+/// - `query` must be a valid pointer returned from `lancedb_vector_query_new`
+/// - `expr` must be a valid pointer returned from `lancedb_expr_*` functions
+/// - `expr` is consumed by this function; do not use or free it after calling
+/// - `error_message` can be NULL to ignore detailed error messages
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_vector_query_df_filter(
+    query: *mut LanceDBVectorQuery,
+    expr: *mut LanceDBExpr,
+    error_message: *mut *mut c_char,
+) -> LanceDBError {
+    if query.is_null() || expr.is_null() {
+        set_invalid_argument_message(error_message);
+        return LanceDBError::InvalidArgument;
+    }
+
+    let expr_box = Box::from_raw(expr);
+    (*query).df_filter = Some(expr_box.inner);
+    LanceDBError::Success
+}
+
 /// Set distance type for vector query
 ///
 /// # Safety
@@ -491,7 +543,9 @@ pub unsafe extern "C" fn lancedb_query_execute(
         if let Some(ref select) = query_box.select {
             rust_query = rust_query.select(select.clone());
         }
-        if let Some(ref filter) = query_box.filter {
+        if let Some(df_filter) = query_box.df_filter {
+            rust_query.mut_query().filter = Some(QueryFilter::Datafusion(df_filter));
+        } else if let Some(ref filter) = query_box.filter {
             rust_query = rust_query.only_if(filter);
         }
 
@@ -545,7 +599,9 @@ pub unsafe extern "C" fn lancedb_vector_query_execute(
         if let Some(ref select) = query_box.select {
             rust_query = rust_query.select(select.clone());
         }
-        if let Some(ref filter) = query_box.filter {
+        if let Some(df_filter) = query_box.df_filter {
+            rust_query.mut_query().filter = Some(QueryFilter::Datafusion(df_filter));
+        } else if let Some(ref filter) = query_box.filter {
             rust_query = rust_query.only_if(filter);
         }
         if let Some(distance_type) = query_box.distance_type {

--- a/tests/test_df_query.cpp
+++ b/tests/test_df_query.cpp
@@ -1,0 +1,841 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright The LanceDB Authors
+ */
+
+#include "test_common.h"
+
+static void verify_query_result(LanceDBQueryResult* query_result, size_t expected_rows) {
+  // Convert to Arrow
+  FFI_ArrowArray** result_arrays = nullptr;
+  FFI_ArrowSchema* result_schema = nullptr;
+  size_t count = 0;
+  char* error_message = nullptr;
+  const auto result = lancedb_query_result_to_arrow(
+      query_result, &result_arrays, &result_schema, &count, &error_message);
+
+  REQUIRE(result == LANCEDB_SUCCESS);
+  REQUIRE(error_message == nullptr);
+  REQUIRE(count > 0);
+  REQUIRE(result_arrays != nullptr);
+  REQUIRE(result_schema != nullptr);
+
+  // Count total rows across all batches
+  size_t sum_rows = 0;
+  for (size_t i = 0; i < count; i++) {
+    sum_rows += reinterpret_cast<ArrowArray*>(result_arrays[i])->length;
+  }
+  REQUIRE(sum_rows == expected_rows);
+
+  // Verify schema has 2 columns
+  REQUIRE(reinterpret_cast<ArrowSchema*>(result_schema)->n_children == 2);
+
+  // Clean up
+  lancedb_free_arrow_arrays(result_arrays, count);
+  lancedb_free_arrow_schema(result_schema);
+}
+
+static void create_key_index(LanceDBTable* table) {
+  // Create BTREE index on "key" column
+  const char* index_columns[] = {"key"};
+  LanceDBScalarIndexConfig config = {
+    .replace = 0,
+    .force_update_statistics = 0
+  };
+
+  char* error_message = nullptr;
+  LanceDBError result = lancedb_table_create_scalar_index(
+      table, index_columns, 1, LANCEDB_INDEX_BTREE, &config, &error_message);
+
+  REQUIRE(result == LANCEDB_SUCCESS);
+  REQUIRE(error_message == nullptr);
+}
+
+TEST_CASE_METHOD(LanceDBFixture, "LanceDB Query - DataFusion Expr Filter", "[query][expr]") {
+  const std::string table_name = "query_df_filter_test";
+
+  // Create table with data
+  LanceDBTable* table = create_table_with_data(table_name, 100, 0);
+  REQUIRE(table != nullptr);
+
+  create_key_index(table);
+
+  SECTION("Filter by single key using Expr") {
+    // Build expr: key = "key_42"
+    LanceDBExpr* col_expr = lancedb_expr_column("key");
+    REQUIRE(col_expr != nullptr);
+    LanceDBExpr* val_expr = lancedb_expr_literal_string("key_42");
+    REQUIRE(val_expr != nullptr);
+    LanceDBExpr* eq_expr = lancedb_expr_binary(col_expr, LANCEDB_BINARY_OP_EQ, val_expr);
+    REQUIRE(eq_expr != nullptr);
+
+    LanceDBQuery* query = lancedb_query_new(table);
+    REQUIRE(query != nullptr);
+
+    const char* columns[] = {"key", "data"};
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_query_select(query, columns, 2, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    error_message = nullptr;
+    result = lancedb_query_df_filter(query, eq_expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    LanceDBQueryResult* query_result = lancedb_query_execute(query);
+    REQUIRE(query_result != nullptr);
+
+    verify_query_result(query_result, 1);
+  }
+
+  SECTION("Filter by IN list using Expr") {
+    // Build expr: key IN ("key_10", "key_20", "key_30", "key_40", "key_50")
+    LanceDBExpr* col_expr = lancedb_expr_column("key");
+    REQUIRE(col_expr != nullptr);
+
+    LanceDBExpr* list_items[5];
+    list_items[0] = lancedb_expr_literal_string("key_10");
+    list_items[1] = lancedb_expr_literal_string("key_20");
+    list_items[2] = lancedb_expr_literal_string("key_30");
+    list_items[3] = lancedb_expr_literal_string("key_40");
+    list_items[4] = lancedb_expr_literal_string("key_50");
+    for (auto& item : list_items) {
+      REQUIRE(item != nullptr);
+    }
+
+    char* error_message = nullptr;
+    LanceDBExpr* in_expr = lancedb_expr_in_list(col_expr, list_items, 5, false, &error_message);
+    REQUIRE(in_expr != nullptr);
+    REQUIRE(error_message == nullptr);
+    // col_expr and all list_items are consumed
+
+    LanceDBQuery* query = lancedb_query_new(table);
+    REQUIRE(query != nullptr);
+
+    const char* columns[] = {"key", "data"};
+    error_message = nullptr;
+    LanceDBError result = lancedb_query_select(query, columns, 2, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    error_message = nullptr;
+    result = lancedb_query_df_filter(query, in_expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    LanceDBQueryResult* query_result = lancedb_query_execute(query);
+    REQUIRE(query_result != nullptr);
+
+    verify_query_result(query_result, 5);
+  }
+
+  SECTION("Expr NOT") {
+    // Build expr: NOT (key = "key_42")
+    LanceDBExpr* col_expr = lancedb_expr_column("key");
+    LanceDBExpr* val_expr = lancedb_expr_literal_string("key_42");
+    LanceDBExpr* eq_expr = lancedb_expr_binary(col_expr, LANCEDB_BINARY_OP_EQ, val_expr);
+    LanceDBExpr* not_expr = lancedb_expr_not(eq_expr);
+    REQUIRE(not_expr != nullptr);
+
+    LanceDBQuery* query = lancedb_query_new(table);
+    REQUIRE(query != nullptr);
+
+    const char* columns[] = {"key", "data"};
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_query_select(query, columns, 2, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    result = lancedb_query_df_filter(query, not_expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    LanceDBQueryResult* query_result = lancedb_query_execute(query);
+    REQUIRE(query_result != nullptr);
+
+    verify_query_result(query_result, 99);
+  }
+
+  SECTION("Expr AND combining two conditions") {
+    // Build expr: key = "key_42" AND key > "key_41"
+    // (tautological AND to test the AND combinator)
+    LanceDBExpr* eq1 = lancedb_expr_binary(
+        lancedb_expr_column("key"),
+        LANCEDB_BINARY_OP_EQ,
+        lancedb_expr_literal_string("key_42"));
+    LanceDBExpr* eq2 = lancedb_expr_binary(
+        lancedb_expr_column("key"),
+        LANCEDB_BINARY_OP_GT,
+        lancedb_expr_literal_string("key_41"));
+    LanceDBExpr* and_expr = lancedb_expr_and(eq1, eq2);
+    REQUIRE(and_expr != nullptr);
+
+    LanceDBQuery* query = lancedb_query_new(table);
+    REQUIRE(query != nullptr);
+
+    const char* columns[] = {"key", "data"};
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_query_select(query, columns, 2, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+    result = lancedb_query_df_filter(query, and_expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    LanceDBQueryResult* query_result = lancedb_query_execute(query);
+    REQUIRE(query_result != nullptr);
+    verify_query_result(query_result, 1);
+  }
+
+  SECTION("Expr OR combining two conditions") {
+    // Build expr: key = "key_10" OR key = "key_20"
+    LanceDBExpr* eq1 = lancedb_expr_binary(
+        lancedb_expr_column("key"),
+        LANCEDB_BINARY_OP_EQ,
+        lancedb_expr_literal_string("key_10"));
+    LanceDBExpr* eq2 = lancedb_expr_binary(
+        lancedb_expr_column("key"),
+        LANCEDB_BINARY_OP_EQ,
+        lancedb_expr_literal_string("key_20"));
+    LanceDBExpr* or_expr = lancedb_expr_or(eq1, eq2);
+    REQUIRE(or_expr != nullptr);
+
+    LanceDBQuery* query = lancedb_query_new(table);
+    REQUIRE(query != nullptr);
+
+    const char* columns[] = {"key", "data"};
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_query_select(query, columns, 2, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+    result = lancedb_query_df_filter(query, or_expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    LanceDBQueryResult* query_result = lancedb_query_execute(query);
+    REQUIRE(query_result != nullptr);
+    verify_query_result(query_result, 2);
+  }
+
+  SECTION("Expr clone") {
+    LanceDBExpr* original = lancedb_expr_binary(
+        lancedb_expr_column("key"),
+        LANCEDB_BINARY_OP_EQ,
+        lancedb_expr_literal_string("key_42"));
+    REQUIRE(original != nullptr);
+
+    LanceDBExpr* another_eq = lancedb_expr_binary(
+        lancedb_expr_column("key"),
+        LANCEDB_BINARY_OP_EQ,
+        lancedb_expr_literal_string("key_24"));
+    REQUIRE(another_eq != nullptr);
+    // cloned include the original with an OR condition
+    LanceDBExpr* cloned = lancedb_expr_or(
+        lancedb_expr_clone(original),
+        another_eq);
+    REQUIRE(cloned != nullptr);
+
+    // Use original in first query
+    LanceDBQuery* query1 = lancedb_query_new(table);
+    REQUIRE(query1 != nullptr);
+    const char* columns[] = {"key", "data"};
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_query_select(query1, columns, 2, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+    result = lancedb_query_df_filter(query1, original, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+    LanceDBQueryResult* result1 = lancedb_query_execute(query1);
+    REQUIRE(result1 != nullptr);
+    verify_query_result(result1, 1);
+
+    // Use clone in second query
+    LanceDBQuery* query2 = lancedb_query_new(table);
+    REQUIRE(query2 != nullptr);
+    result = lancedb_query_select(query2, columns, 2, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+    result = lancedb_query_df_filter(query2, cloned, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+    LanceDBQueryResult* result2 = lancedb_query_execute(query2);
+    REQUIRE(result2 != nullptr);
+    verify_query_result(result2, 2);
+  }
+
+  SECTION("Null arguments") {
+    char* error_message = nullptr;
+    LanceDBQuery* query = lancedb_query_new(table);
+    REQUIRE(query != nullptr);
+
+    // Null expr
+    LanceDBError result = lancedb_query_df_filter(query, nullptr, &error_message);
+    REQUIRE(result == LANCEDB_INVALID_ARGUMENT);
+    REQUIRE(error_message != nullptr);
+    lancedb_free_string(error_message);
+    error_message = nullptr;
+
+    // Null query
+    LanceDBExpr* expr = lancedb_expr_column("key");
+    result = lancedb_query_df_filter(nullptr, expr, &error_message);
+    REQUIRE(result == LANCEDB_INVALID_ARGUMENT);
+    REQUIRE(error_message != nullptr);
+    lancedb_free_string(error_message);
+    lancedb_expr_free(expr);
+
+    lancedb_query_free(query);
+  }
+
+  SECTION("Filter by unknown key using Expr (should return empty result)") {
+    // Build expr: key = "key_999" (doesn't exist in table with key_0 to key_99)
+    LanceDBExpr* eq_expr = lancedb_expr_binary(
+        lancedb_expr_column("key"),
+        LANCEDB_BINARY_OP_EQ,
+        lancedb_expr_literal_string("key_999"));
+    REQUIRE(eq_expr != nullptr);
+
+    LanceDBQuery* query = lancedb_query_new(table);
+    REQUIRE(query != nullptr);
+
+    const char* columns[] = {"key", "data"};
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_query_select(query, columns, 2, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    result = lancedb_query_df_filter(query, eq_expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    LanceDBQueryResult* query_result = lancedb_query_execute(query);
+    REQUIRE(query_result != nullptr);
+
+    // Convert to Arrow - should return empty result
+    FFI_ArrowArray** result_arrays = nullptr;
+    FFI_ArrowSchema* result_schema = nullptr;
+    size_t count = 0;
+    result = lancedb_query_result_to_arrow(
+        query_result, &result_arrays, &result_schema, &count, &error_message);
+
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(count == 0);
+    REQUIRE(result_arrays == nullptr);
+    REQUIRE(result_schema == nullptr);
+  }
+
+  SECTION("Filter on non-existent column using Expr (should fail at execution)") {
+    // Build expr: nonexistent_column = "value"
+    LanceDBExpr* eq_expr = lancedb_expr_binary(
+        lancedb_expr_column("nonexistent_column"),
+        LANCEDB_BINARY_OP_EQ,
+        lancedb_expr_literal_string("value"));
+    REQUIRE(eq_expr != nullptr);
+
+    LanceDBQuery* query = lancedb_query_new(table);
+    REQUIRE(query != nullptr);
+
+    const char* columns[] = {"key", "data"};
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_query_select(query, columns, 2, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    result = lancedb_query_df_filter(query, eq_expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    // Error should be caught at execution time
+    LanceDBQueryResult* query_result = lancedb_query_execute(query);
+    REQUIRE(query_result == nullptr);
+  }
+
+  SECTION("DataFusion filter takes precedence over SQL filter") {
+    // Set SQL filter that matches key_10 only
+    LanceDBQuery* query = lancedb_query_new(table);
+    REQUIRE(query != nullptr);
+
+    const char* columns[] = {"key", "data"};
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_query_select(query, columns, 2, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    // SQL filter: key = "key_10" (would return 1 row)
+    error_message = nullptr;
+    result = lancedb_query_where_filter(query, "key = \"key_10\"", &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    // DataFusion filter: key = "key_42" (should override SQL filter)
+    LanceDBExpr* expr = lancedb_expr_binary(
+        lancedb_expr_column("key"),
+        LANCEDB_BINARY_OP_EQ,
+        lancedb_expr_literal_string("key_42"));
+    REQUIRE(expr != nullptr);
+
+    error_message = nullptr;
+    result = lancedb_query_df_filter(query, expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    // Execute - should return key_42, not key_10
+    LanceDBQueryResult* query_result = lancedb_query_execute(query);
+    REQUIRE(query_result != nullptr);
+
+    // Convert to Arrow and verify the returned key is "key_42"
+    FFI_ArrowArray** result_arrays = nullptr;
+    FFI_ArrowSchema* result_schema = nullptr;
+    size_t count = 0;
+    error_message = nullptr;
+    result = lancedb_query_result_to_arrow(
+        query_result, &result_arrays, &result_schema, &count, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+    REQUIRE(count == 1);
+
+    // Import into Arrow RecordBatch to inspect the key value
+    auto imported_schema = arrow::ImportSchema(
+        reinterpret_cast<ArrowSchema*>(result_schema));
+    REQUIRE(imported_schema.ok());
+
+    auto imported_batch = arrow::ImportRecordBatch(
+        reinterpret_cast<ArrowArray*>(result_arrays[0]),
+        imported_schema.ValueUnsafe());
+    REQUIRE(imported_batch.ok());
+
+    auto batch = imported_batch.ValueUnsafe();
+    REQUIRE(batch->num_rows() == 1);
+
+    auto key_array = std::static_pointer_cast<arrow::StringArray>(
+        batch->column(0));
+    REQUIRE(key_array->GetString(0) == "key_42");
+
+    // Clean up
+    lancedb_free_arrow_arrays(result_arrays, count);
+    lancedb_free_arrow_schema(result_schema);
+  }
+
+  SECTION("Expr free on NULL is safe") {
+    lancedb_expr_free(nullptr);
+  }
+
+  SECTION("Expr builder NULL arguments") {
+    REQUIRE(lancedb_expr_column(nullptr) == nullptr);
+    REQUIRE(lancedb_expr_literal_string(nullptr) == nullptr);
+    REQUIRE(lancedb_expr_binary(nullptr, LANCEDB_BINARY_OP_EQ, nullptr) == nullptr);
+    REQUIRE(lancedb_expr_not(nullptr) == nullptr);
+    REQUIRE(lancedb_expr_is_null(nullptr) == nullptr);
+    REQUIRE(lancedb_expr_is_not_null(nullptr) == nullptr);
+    REQUIRE(lancedb_expr_and(nullptr, nullptr) == nullptr);
+    REQUIRE(lancedb_expr_or(nullptr, nullptr) == nullptr);
+    REQUIRE(lancedb_expr_clone(nullptr) == nullptr);
+  }
+
+  SECTION("Partial NULL arguments consume non-null expr (binary)") {
+    LanceDBExpr* left = lancedb_expr_column("key");
+    REQUIRE(left != nullptr);
+    REQUIRE(lancedb_expr_binary(left, LANCEDB_BINARY_OP_EQ, nullptr) == nullptr);
+
+    LanceDBExpr* right = lancedb_expr_literal_string("value");
+    REQUIRE(right != nullptr);
+    REQUIRE(lancedb_expr_binary(nullptr, LANCEDB_BINARY_OP_EQ, right) == nullptr);
+  }
+
+  SECTION("Partial NULL arguments consume non-null expr (and)") {
+    LanceDBExpr* left = lancedb_expr_literal_bool(true);
+    REQUIRE(left != nullptr);
+    REQUIRE(lancedb_expr_and(left, nullptr) == nullptr);
+
+    LanceDBExpr* right = lancedb_expr_literal_bool(false);
+    REQUIRE(right != nullptr);
+    REQUIRE(lancedb_expr_and(nullptr, right) == nullptr);
+  }
+
+  SECTION("Partial NULL arguments consume non-null expr (or)") {
+    LanceDBExpr* left = lancedb_expr_literal_bool(true);
+    REQUIRE(left != nullptr);
+    REQUIRE(lancedb_expr_or(left, nullptr) == nullptr);
+
+    LanceDBExpr* right = lancedb_expr_literal_bool(false);
+    REQUIRE(right != nullptr);
+    REQUIRE(lancedb_expr_or(nullptr, right) == nullptr);
+  }
+
+  SECTION("Partial NULL arguments consume non-null expr (in_list)") {
+    // expr is valid, list is NULL — expr must still be consumed
+    char* error_message = nullptr;
+    LanceDBExpr* expr = lancedb_expr_column("key");
+    REQUIRE(expr != nullptr);
+    REQUIRE(lancedb_expr_in_list(expr, nullptr, 0, false, &error_message) == nullptr);
+    REQUIRE(error_message != nullptr);
+    lancedb_free_string(error_message);
+    error_message = nullptr;
+
+    // expr is valid, list has a NULL element — expr and non-null items must be consumed
+    LanceDBExpr* list_items[2];
+    list_items[0] = lancedb_expr_literal_string("value1");
+    list_items[1] = nullptr;
+    expr = lancedb_expr_column("key");
+    REQUIRE(expr != nullptr);
+    REQUIRE(lancedb_expr_in_list(expr, list_items, 2, false, &error_message) == nullptr);
+    REQUIRE(error_message != nullptr);
+    lancedb_free_string(error_message);
+  }
+
+  lancedb_table_free(table);
+}
+
+TEST_CASE_METHOD(LanceDBFixture, "LanceDB Query - Expr Type Mismatches", "[query][expr]") {
+  // Create a table schema with numeric-only string keys ("0", "1", ..., "9")
+  auto schema = create_test_schema();
+
+  arrow::StringBuilder key_builder;
+  arrow::FixedSizeListBuilder data_builder(arrow::default_memory_pool(),
+      std::make_unique<arrow::FloatBuilder>(), TEST_SCHEMA_DIMENSIONS);
+
+  for (int i = 0; i < 10; i++) {
+    REQUIRE(key_builder.Append(std::to_string(i)).ok());
+    REQUIRE(data_builder.Append().ok());
+    auto list_builder = static_cast<arrow::FloatBuilder*>(data_builder.value_builder());
+    for (size_t j = 0; j < TEST_SCHEMA_DIMENSIONS; j++) {
+      REQUIRE(list_builder->Append(static_cast<float>(i * 10 + j)).ok());
+    }
+  }
+
+  std::shared_ptr<arrow::Array> key_array, data_array;
+  REQUIRE(key_builder.Finish(&key_array).ok());
+  REQUIRE(data_builder.Finish(&data_array).ok());
+
+  auto batch = arrow::RecordBatch::Make(schema, 10, {key_array, data_array});
+  auto reader = create_reader_from_batch(batch);
+  REQUIRE(reader != nullptr);
+
+  struct ArrowSchema c_schema;
+  REQUIRE(arrow::ExportSchema(*schema, &c_schema).ok());
+
+  LanceDBTable* table = nullptr;
+  char* error_message = nullptr;
+  LanceDBError result = lancedb_table_create(
+      db, "numeric_keys_test",
+      reinterpret_cast<FFI_ArrowSchema*>(&c_schema),
+      reader, &table, &error_message);
+  REQUIRE(result == LANCEDB_SUCCESS);
+  REQUIRE(table != nullptr);
+  if (c_schema.release) {
+    c_schema.release(&c_schema);
+  }
+
+  SECTION("Arithmetic on non-numeric column (string + int)") {
+    // Build expr: key + 1 (key is utf8, not numeric)
+    LanceDBExpr* expr = lancedb_expr_binary(
+        lancedb_expr_column("key"),
+        LANCEDB_BINARY_OP_PLUS,
+        lancedb_expr_literal_i64(1));
+    REQUIRE(expr != nullptr);
+
+    LanceDBQuery* query = lancedb_query_new(table);
+    REQUIRE(query != nullptr);
+
+    const char* columns[] = {"key", "data"};
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_query_select(query, columns, 2, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    result = lancedb_query_df_filter(query, expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    // Should fail at execution due to type mismatch
+    LanceDBQueryResult* query_result = lancedb_query_execute(query);
+    REQUIRE(query_result == nullptr);
+  }
+
+  SECTION("Equality with type coercion (string column vs. int") {
+    // Build expr: key = 5 (key is utf8 but values are numeric strings)
+    // DataFusion coerces int to string, matching row with key "5"
+    LanceDBExpr* expr = lancedb_expr_binary(
+        lancedb_expr_column("key"),
+        LANCEDB_BINARY_OP_EQ,
+        lancedb_expr_literal_i64(5));
+    REQUIRE(expr != nullptr);
+
+    LanceDBQuery* query = lancedb_query_new(table);
+    REQUIRE(query != nullptr);
+
+    const char* columns[] = {"key", "data"};
+    result = lancedb_query_select(query, columns, 2, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    result = lancedb_query_df_filter(query, expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    LanceDBQueryResult* query_result = lancedb_query_execute(query);
+    REQUIRE(query_result != nullptr);
+
+    // Coercion works: should match exactly one row (key "5")
+    verify_query_result(query_result, 1);
+  }
+
+  SECTION("Boolean AND on non-boolean expressions (int AND int)") {
+    // Build expr: 42 AND 7 (both are i64, not boolean)
+    LanceDBExpr* expr = lancedb_expr_and(
+        lancedb_expr_literal_i64(42),
+        lancedb_expr_literal_i64(7));
+    REQUIRE(expr != nullptr);
+
+    LanceDBQuery* query = lancedb_query_new(table);
+    REQUIRE(query != nullptr);
+
+    const char* columns[] = {"key", "data"};
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_query_select(query, columns, 2, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    result = lancedb_query_df_filter(query, expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    // Should fail at execution due to type mismatch
+    LanceDBQueryResult* query_result = lancedb_query_execute(query);
+    REQUIRE(query_result == nullptr);
+  }
+
+  SECTION("Boolean OR on string expressions") {
+    // Build expr: "hello" OR "world" (strings, not boolean)
+    LanceDBExpr* expr = lancedb_expr_or(
+        lancedb_expr_literal_string("hello"),
+        lancedb_expr_literal_string("world"));
+    REQUIRE(expr != nullptr);
+
+    LanceDBQuery* query = lancedb_query_new(table);
+    REQUIRE(query != nullptr);
+
+    const char* columns[] = {"key", "data"};
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_query_select(query, columns, 2, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    result = lancedb_query_df_filter(query, expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    // Should fail at execution due to type mismatch
+    LanceDBQueryResult* query_result = lancedb_query_execute(query);
+    REQUIRE(query_result == nullptr);
+  }
+
+  SECTION("NOT on non-boolean expression (NOT int)") {
+    // Build expr: NOT 42 (i64, not boolean)
+    LanceDBExpr* expr = lancedb_expr_not(lancedb_expr_literal_i64(42));
+    REQUIRE(expr != nullptr);
+
+    LanceDBQuery* query = lancedb_query_new(table);
+    REQUIRE(query != nullptr);
+
+    const char* columns[] = {"key", "data"};
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_query_select(query, columns, 2, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    result = lancedb_query_df_filter(query, expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    // Should fail at execution due to type mismatch
+    LanceDBQueryResult* query_result = lancedb_query_execute(query);
+    REQUIRE(query_result == nullptr);
+  }
+
+  SECTION("Comparison between string literal and float literal") {
+    // Build expr: "hello" > 3.14
+    // DataFusion coerces types, so the query succeeds
+    LanceDBExpr* expr = lancedb_expr_binary(
+        lancedb_expr_literal_string("hello"),
+        LANCEDB_BINARY_OP_GT,
+        lancedb_expr_literal_f64(3.14));
+    REQUIRE(expr != nullptr);
+
+    LanceDBQuery* query = lancedb_query_new(table);
+    REQUIRE(query != nullptr);
+
+    const char* columns[] = {"key", "data"};
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_query_select(query, columns, 2, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+
+    result = lancedb_query_df_filter(query, expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    // DataFusion coerces and evaluates this - query succeeds
+    LanceDBQueryResult* query_result = lancedb_query_execute(query);
+    REQUIRE(query_result != nullptr);
+    lancedb_query_result_free(query_result);
+  }
+
+  SECTION("IN list with float literal against vector column") {
+    // Build expr: 3.14 IN (data)
+    LanceDBExpr* col_expr = lancedb_expr_column("data");
+    REQUIRE(col_expr != nullptr);
+
+    char* error_message = nullptr;
+    LanceDBExpr* in_expr = lancedb_expr_in_list(
+        lancedb_expr_literal_f64(3.14), &col_expr, 1, false, &error_message);
+    REQUIRE(in_expr != nullptr);
+    REQUIRE(error_message == nullptr);
+
+    LanceDBQuery* query = lancedb_query_new(table);
+    REQUIRE(query != nullptr);
+
+    const char* columns[] = {"key", "data"};
+    LanceDBError result = lancedb_query_select(query, columns, 2, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    result = lancedb_query_df_filter(query, in_expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    // Should fail at execution — cannot use IN with a vector column
+    LanceDBQueryResult* query_result = lancedb_query_execute(query);
+    REQUIRE(query_result == nullptr);
+  }
+
+  SECTION("IN list with string column against int literals") {
+    // Build expr: key IN (1, 2, 3)
+    LanceDBExpr* col_expr = lancedb_expr_column("key");
+    LanceDBExpr* list_items[3];
+    list_items[0] = lancedb_expr_literal_i64(1);
+    list_items[1] = lancedb_expr_literal_i64(2);
+    list_items[2] = lancedb_expr_literal_i64(3);
+
+    char* error_message = nullptr;
+    LanceDBExpr* in_expr = lancedb_expr_in_list(
+        col_expr,
+        list_items, 3, false, &error_message);
+    REQUIRE(in_expr != nullptr);
+    REQUIRE(error_message == nullptr);
+
+    LanceDBQuery* query = lancedb_query_new(table);
+    REQUIRE(query != nullptr);
+
+    const char* columns[] = {"key", "data"};
+    LanceDBError result = lancedb_query_select(query, columns, 2, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    result = lancedb_query_df_filter(query, in_expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    // DataFusion coerces ints to strings so query suceeds
+    LanceDBQueryResult* query_result = lancedb_query_execute(query);
+    REQUIRE(query_result != nullptr);
+
+    FFI_ArrowArray** result_arrays = nullptr;
+    FFI_ArrowSchema* result_schema = nullptr;
+    size_t count = 0;
+    result = lancedb_query_result_to_arrow(
+        query_result, &result_arrays, &result_schema, &count, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(count == 1);
+
+    // Import into Arrow RecordBatch to inspect the key value
+    auto imported_schema = arrow::ImportSchema(
+        reinterpret_cast<ArrowSchema*>(result_schema));
+    REQUIRE(imported_schema.ok());
+
+    auto imported_batch = arrow::ImportRecordBatch(
+        reinterpret_cast<ArrowArray*>(result_arrays[0]),
+        imported_schema.ValueUnsafe());
+    REQUIRE(imported_batch.ok());
+
+    auto batch = imported_batch.ValueUnsafe();
+    REQUIRE(batch->num_rows() == 3);
+
+    // Clean up
+    lancedb_free_arrow_arrays(result_arrays, count);
+    lancedb_free_arrow_schema(result_schema);
+  }
+
+  SECTION("IN list with string literal against string literal (not a list)") {
+    // Build expr: "hello" IN ("hello world")
+    LanceDBExpr* list_item = lancedb_expr_literal_string("hello world");
+    REQUIRE(list_item != nullptr);
+
+    char* error_message = nullptr;
+    LanceDBExpr* in_expr = lancedb_expr_in_list(
+        lancedb_expr_literal_string("hello"), &list_item, 1, false, &error_message);
+    REQUIRE(in_expr != nullptr);
+    REQUIRE(error_message == nullptr);
+
+    LanceDBQuery* query = lancedb_query_new(table);
+    REQUIRE(query != nullptr);
+
+    const char* columns[] = {"key", "data"};
+    LanceDBError result = lancedb_query_select(query, columns, 2, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    result = lancedb_query_df_filter(query, in_expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    // "hello" != "hello world" no substring matching, just equality
+    LanceDBQueryResult* query_result = lancedb_query_execute(query);
+    REQUIRE(query_result != nullptr);
+
+    FFI_ArrowArray** result_arrays = nullptr;
+    FFI_ArrowSchema* result_schema = nullptr;
+    size_t count = 0;
+    result = lancedb_query_result_to_arrow(
+        query_result, &result_arrays, &result_schema, &count, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    // Constant false filter: no rows returned
+    REQUIRE(count == 0);
+  }
+
+  SECTION("Comparison with boolean sub-expression (int > bool)") {
+    // Build expr: 42 > (42 > 7)
+    // Inner: 42 > 7 produces a boolean
+    // Outer: 42 > <boolean> is a type mismatch (int vs bool)
+    LanceDBExpr* inner = lancedb_expr_binary(
+        lancedb_expr_literal_i64(42),
+        LANCEDB_BINARY_OP_GT,
+        lancedb_expr_literal_i64(7));
+    REQUIRE(inner != nullptr);
+
+    LanceDBExpr* expr = lancedb_expr_binary(
+        lancedb_expr_literal_i64(42),
+        LANCEDB_BINARY_OP_GT,
+        inner);
+    REQUIRE(expr != nullptr);
+
+    LanceDBQuery* query = lancedb_query_new(table);
+    REQUIRE(query != nullptr);
+
+    const char* columns[] = {"key", "data"};
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_query_select(query, columns, 2, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    result = lancedb_query_df_filter(query, expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    // Should fail at execution due to type mismatch
+    LanceDBQueryResult* query_result = lancedb_query_execute(query);
+    REQUIRE(query_result == nullptr);
+  }
+
+  lancedb_table_free(table);
+}

--- a/tests/test_vector_query.cpp
+++ b/tests/test_vector_query.cpp
@@ -858,6 +858,240 @@ TEST_CASE_METHOD(LanceDBFixture, "LanceDB Vector Query - Filter on non-existent 
   lancedb_table_free(table);
 }
 
+TEST_CASE_METHOD(LanceDBFixture, "LanceDB Vector Query - DataFusion Expr Filter", "[vector_query][expr]") {
+  const std::string table_name = "vector_query_df_filter_test";
+  constexpr size_t total_rows = 100;
+
+  // Create table with data
+  LanceDBTable* table = create_table_with_data(table_name, total_rows, 0);
+  REQUIRE(table != nullptr);
+
+  SECTION("Vector query with Expr filter by single key") {
+    std::vector<float> query_vector = generate_random_query_vector(TEST_SCHEMA_DIMENSIONS);
+
+    LanceDBVectorQuery* query = lancedb_vector_query_new(
+        table, query_vector.data(), TEST_SCHEMA_DIMENSIONS);
+    REQUIRE(query != nullptr);
+
+    // Build expr: key = "key_42"
+    LanceDBExpr* eq_expr = lancedb_expr_binary(
+        lancedb_expr_column("key"),
+        LANCEDB_BINARY_OP_EQ,
+        lancedb_expr_literal_string("key_42"));
+    REQUIRE(eq_expr != nullptr);
+
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_vector_query_df_filter(query, eq_expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(error_message == nullptr);
+
+    result = lancedb_vector_query_limit(query, 10, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+
+    LanceDBQueryResult* query_result = lancedb_vector_query_execute(query);
+    REQUIRE(query_result != nullptr);
+
+    FFI_ArrowArray** result_arrays = nullptr;
+    FFI_ArrowSchema* result_schema = nullptr;
+    size_t count = 0;
+    result = lancedb_query_result_to_arrow(
+        query_result, &result_arrays, &result_schema, &count, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(count > 0);
+
+    size_t sum_rows = 0;
+    for (size_t i = 0; i < count; i++) {
+      sum_rows += reinterpret_cast<ArrowArray*>(result_arrays[i])->length;
+    }
+    REQUIRE(sum_rows == 1);
+
+    lancedb_free_arrow_arrays(result_arrays, count);
+    lancedb_free_arrow_schema(result_schema);
+  }
+
+  SECTION("Vector query with Expr IN list filter") {
+    std::vector<float> query_vector = generate_random_query_vector(TEST_SCHEMA_DIMENSIONS);
+
+    LanceDBVectorQuery* query = lancedb_vector_query_new(
+        table, query_vector.data(), TEST_SCHEMA_DIMENSIONS);
+    REQUIRE(query != nullptr);
+
+    // Build expr: key IN ("key_10", "key_20", "key_30")
+    LanceDBExpr* col_expr = lancedb_expr_column("key");
+    LanceDBExpr* list_items[3];
+    list_items[0] = lancedb_expr_literal_string("key_10");
+    list_items[1] = lancedb_expr_literal_string("key_20");
+    list_items[2] = lancedb_expr_literal_string("key_30");
+
+    char* error_message = nullptr;
+    LanceDBExpr* in_expr = lancedb_expr_in_list(col_expr, list_items, 3, false, &error_message);
+    REQUIRE(in_expr != nullptr);
+
+    LanceDBError result = lancedb_vector_query_df_filter(query, in_expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+
+    result = lancedb_vector_query_limit(query, 10, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+
+    LanceDBQueryResult* query_result = lancedb_vector_query_execute(query);
+    REQUIRE(query_result != nullptr);
+
+    FFI_ArrowArray** result_arrays = nullptr;
+    FFI_ArrowSchema* result_schema = nullptr;
+    size_t count = 0;
+    result = lancedb_query_result_to_arrow(
+        query_result, &result_arrays, &result_schema, &count, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(count > 0);
+
+    size_t sum_rows = 0;
+    for (size_t i = 0; i < count; i++) {
+      sum_rows += reinterpret_cast<ArrowArray*>(result_arrays[i])->length;
+    }
+    REQUIRE(sum_rows == 3);
+
+    lancedb_free_arrow_arrays(result_arrays, count);
+    lancedb_free_arrow_schema(result_schema);
+  }
+
+  SECTION("Vector query with Expr OR filter") {
+    std::vector<float> query_vector = generate_random_query_vector(TEST_SCHEMA_DIMENSIONS);
+
+    LanceDBVectorQuery* query = lancedb_vector_query_new(
+        table, query_vector.data(), TEST_SCHEMA_DIMENSIONS);
+    REQUIRE(query != nullptr);
+
+    // Build expr: key = "key_10" OR key = "key_20"
+    LanceDBExpr* or_expr = lancedb_expr_or(
+        lancedb_expr_binary(
+            lancedb_expr_column("key"),
+            LANCEDB_BINARY_OP_EQ,
+            lancedb_expr_literal_string("key_10")),
+        lancedb_expr_binary(
+            lancedb_expr_column("key"),
+            LANCEDB_BINARY_OP_EQ,
+            lancedb_expr_literal_string("key_20")));
+    REQUIRE(or_expr != nullptr);
+
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_vector_query_df_filter(query, or_expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+
+    result = lancedb_vector_query_limit(query, 10, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+
+    LanceDBQueryResult* query_result = lancedb_vector_query_execute(query);
+    REQUIRE(query_result != nullptr);
+
+    FFI_ArrowArray** result_arrays = nullptr;
+    FFI_ArrowSchema* result_schema = nullptr;
+    size_t count = 0;
+    result = lancedb_query_result_to_arrow(
+        query_result, &result_arrays, &result_schema, &count, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(count > 0);
+
+    size_t sum_rows = 0;
+    for (size_t i = 0; i < count; i++) {
+      sum_rows += reinterpret_cast<ArrowArray*>(result_arrays[i])->length;
+    }
+    REQUIRE(sum_rows == 2);
+
+    lancedb_free_arrow_arrays(result_arrays, count);
+    lancedb_free_arrow_schema(result_schema);
+  }
+
+  SECTION("Vector query Expr filter with unknown key (should return empty result)") {
+    std::vector<float> query_vector = generate_random_query_vector(TEST_SCHEMA_DIMENSIONS);
+
+    LanceDBVectorQuery* query = lancedb_vector_query_new(
+        table, query_vector.data(), TEST_SCHEMA_DIMENSIONS);
+    REQUIRE(query != nullptr);
+
+    // Build expr: key = "key_999" (doesn't exist)
+    LanceDBExpr* eq_expr = lancedb_expr_binary(
+        lancedb_expr_column("key"),
+        LANCEDB_BINARY_OP_EQ,
+        lancedb_expr_literal_string("key_999"));
+    REQUIRE(eq_expr != nullptr);
+
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_vector_query_df_filter(query, eq_expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+
+    result = lancedb_vector_query_limit(query, 10, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+
+    LanceDBQueryResult* query_result = lancedb_vector_query_execute(query);
+    REQUIRE(query_result != nullptr);
+
+    FFI_ArrowArray** result_arrays = nullptr;
+    FFI_ArrowSchema* result_schema = nullptr;
+    size_t count = 0;
+    result = lancedb_query_result_to_arrow(
+        query_result, &result_arrays, &result_schema, &count, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+    REQUIRE(count == 0);
+    REQUIRE(result_arrays == nullptr);
+    REQUIRE(result_schema == nullptr);
+  }
+
+  SECTION("Vector query Expr filter on non-existent column (should fail at execution)") {
+    std::vector<float> query_vector = generate_random_query_vector(TEST_SCHEMA_DIMENSIONS);
+
+    LanceDBVectorQuery* query = lancedb_vector_query_new(
+        table, query_vector.data(), TEST_SCHEMA_DIMENSIONS);
+    REQUIRE(query != nullptr);
+
+    // Build expr: nonexistent_column = "value"
+    LanceDBExpr* eq_expr = lancedb_expr_binary(
+        lancedb_expr_column("nonexistent_column"),
+        LANCEDB_BINARY_OP_EQ,
+        lancedb_expr_literal_string("value"));
+    REQUIRE(eq_expr != nullptr);
+
+    char* error_message = nullptr;
+    LanceDBError result = lancedb_vector_query_df_filter(query, eq_expr, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+
+    result = lancedb_vector_query_limit(query, 10, &error_message);
+    REQUIRE(result == LANCEDB_SUCCESS);
+
+    // Error should be caught at execution time
+    LanceDBQueryResult* query_result = lancedb_vector_query_execute(query);
+    REQUIRE(query_result == nullptr);
+  }
+
+  SECTION("Vector query df_filter null arguments") {
+    std::vector<float> query_vector = generate_random_query_vector(TEST_SCHEMA_DIMENSIONS);
+
+    LanceDBVectorQuery* query = lancedb_vector_query_new(
+        table, query_vector.data(), TEST_SCHEMA_DIMENSIONS);
+    REQUIRE(query != nullptr);
+
+    char* error_message = nullptr;
+
+    // Null expr
+    LanceDBError result = lancedb_vector_query_df_filter(query, nullptr, &error_message);
+    REQUIRE(result == LANCEDB_INVALID_ARGUMENT);
+    REQUIRE(error_message != nullptr);
+    lancedb_free_string(error_message);
+    error_message = nullptr;
+
+    // Null query
+    LanceDBExpr* expr = lancedb_expr_column("key");
+    result = lancedb_vector_query_df_filter(nullptr, expr, &error_message);
+    REQUIRE(result == LANCEDB_INVALID_ARGUMENT);
+    REQUIRE(error_message != nullptr);
+    lancedb_free_string(error_message);
+    lancedb_expr_free(expr);
+
+    lancedb_vector_query_free(query);
+  }
+
+  lancedb_table_free(table);
+}
+
 TEST_CASE_METHOD(LanceDBSessionFixture, "LanceDB Vector Query - repeated queries populate session cache stats", "[vector_query][session]") {
   LanceDBSessionCacheStats initial_index_stats{};
   LanceDBSessionCacheStats final_index_stats{};


### PR DESCRIPTION
datafusion expression FFI is added in: srs/expr.rs the apache datafusion project implemented FFI:
https://github.com/apache/datafusion/tree/main/datafusion/ffi

but for expressions it does not support what we need for the lancedb usecase: https://github.com/apache/datafusion/tree/main/datafusion/ffi/src/expr