### PR TITLE
Support to create and insert custom ObjectStoreProvider via session Registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,45 @@ if(BUILD_EXAMPLES)
     BUILD_RPATH ${RUST_TARGET_DIR}
   )
 
-  add_custom_target(examples DEPENDS simple full s3)
+  # external_provider helper crate (provides external_object_store_provider_create)
+  set(EXT_PROVIDER_CARGO_CMD cargo build ${RUST_BUILD_TYPE} ${RUST_TARGET_OPT} --target-dir "${CMAKE_BINARY_DIR}/target")
+  if(WIN32)
+    set(EXT_PROVIDER_SHARED_PATH "${RUST_TARGET_DIR}/lancedb_external_provider${CMAKE_SHARED_LIBRARY_SUFFIX}")
+    set(EXT_PROVIDER_IMPORT_PATH "${RUST_TARGET_DIR}/${CMAKE_IMPORT_LIBRARY_PREFIX}lancedb_external_provider${CMAKE_IMPORT_LIBRARY_SUFFIX}")
+  else()
+    set(EXT_PROVIDER_SHARED_PATH "${RUST_TARGET_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}lancedb_external_provider${CMAKE_SHARED_LIBRARY_SUFFIX}")
+  endif()
+  add_custom_target(external-provider-lib
+    COMMAND ${EXT_PROVIDER_CARGO_CMD}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/examples/external_provider
+    COMMENT "Building external provider Rust crate..."
+    BYPRODUCTS ${EXT_PROVIDER_SHARED_PATH}
+  )
+  add_library(lancedb_external_provider SHARED IMPORTED)
+  set_target_properties(lancedb_external_provider PROPERTIES
+    IMPORTED_LOCATION "${EXT_PROVIDER_SHARED_PATH}"
+    IMPORTED_IMPLIB "${EXT_PROVIDER_IMPORT_PATH}"
+  )
+  add_dependencies(lancedb_external_provider external-provider-lib)
+
+  # lancedb registry example
+  add_executable(lancedb_registry examples/lancedb_registry.cpp)
+  target_link_libraries(lancedb_registry
+    lancedb
+    lancedb_external_provider
+    Threads::Threads
+    ${ARROW_LIBRARIES}
+  )
+  target_include_directories(lancedb_registry
+    PRIVATE ${ARROW_INCLUDE_DIRS}
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+  )
+  target_compile_options(lancedb_registry PRIVATE ${ARROW_CFLAGS_OTHER})
+  set_target_properties(lancedb_registry PROPERTIES
+    BUILD_RPATH ${RUST_TARGET_DIR}
+  )
+
+  add_custom_target(examples DEPENDS simple full s3 lancedb_registry)
 endif()
 
 if(BUILD_DOCS)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,14 @@ rust-version = "1.91.0"
 
 [lib]
 name = "lancedb"
-crate-type = ["cdylib", "staticlib"]
+crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 tokio = { version = "1.23", features = ["rt-multi-thread"] }
 libc = "0.2"
 lancedb = { version = "0.30.0", features = ["remote"] }
 lance = "=7.0.0"
+lance-io = "=7.0.0"
 lance-namespace = "=7.0.0"
 arrow-array = "58.0"
 arrow-data = "58.0"

--- a/examples/external_provider/Cargo.lock
+++ b/examples/external_provider/Cargo.lock
@@ -4385,6 +4385,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "lancedb-external-provider"
+version = "0.1.0"
+dependencies = [
+ "lance-io",
+ "lancedb-c",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/external_provider/Cargo.toml
+++ b/examples/external_provider/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "lancedb-external-provider"
+version = "0.1.0"
+edition = "2021"
+description = "External ObjectStoreProvider example for lancedb-c registry"
+
+[lib]
+name = "lancedb_external_provider"
+crate-type = ["cdylib"]
+
+[dependencies]
+lancedb = { package = "lancedb-c", path = "../.." }
+lance-io = { version = "=7.0.0", default-features = false }

--- a/examples/external_provider/src/lib.rs
+++ b/examples/external_provider/src/lib.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+//! External ObjectStoreProvider example for lancedb-c registry.
+//!
+//! Demonstrates how to create a custom `LanceDBObjectStoreProvider` that can
+//! be inserted into an `LanceDBObjectStoreRegistry` via
+//! `lancedb_registry_insert_provider()`.
+//!
+//! For this example, the provider is initialized with `MemoryStoreProvider`
+//! (an in-memory object store). In practice, this could be replaced with
+//! any `ObjectStoreProvider` implementation (e.g., S3, GCS, Azure, or a
+//! fully custom backend).
+
+use std::sync::Arc;
+
+use lance_io::object_store::providers::memory::MemoryStoreProvider;
+use lance_io::object_store::ObjectStoreProvider;
+use lancedb::LanceDBObjectStoreProvider;
+
+/// Create an external ObjectStoreProvider for use with `lancedb_registry_insert_provider()`
+///
+/// For this example, the provider uses `MemoryStoreProvider` (in-memory storage).
+/// Replace with any `ObjectStoreProvider` implementation for other backends.
+///
+/// # Returns
+/// - Non-null pointer to LanceDBObjectStoreProvider on success
+#[no_mangle]
+pub extern "C" fn external_object_store_provider_create() -> *mut LanceDBObjectStoreProvider {
+    let provider: Arc<dyn ObjectStoreProvider> = Arc::new(MemoryStoreProvider);
+    Box::into_raw(Box::new(LanceDBObjectStoreProvider {
+        inner: Some(provider),
+    }))
+}
+

--- a/examples/lancedb_registry.cpp
+++ b/examples/lancedb_registry.cpp
@@ -1,0 +1,181 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright The LanceDB Authors
+ *
+ * Example: Using the ObjectStoreRegistry APIs
+ *
+ * This example demonstrates how to:
+ * 1. Create a custom ObjectStoreRegistry
+ * 2. Create an in-memory ObjectStoreProvider and insert it into the registry
+ * 3. Create a session with the custom registry
+ * 4. Connect to a memory-backed database
+ * 5. Create a table, list tables, and clean up
+ *
+ * The registry allows customizing which ObjectStoreProvider handles
+ * each URL scheme (e.g., "file", "s3", "memory"). By default, a new
+ * registry comes with providers for local filesystem, S3, memory, etc.
+ * You can override the default provider for a scheme by inserting
+ * a custom one via lancedb_registry_insert_provider().
+ *
+ * The provider is built as a separate Rust crate (examples/s3_provider/)
+ * that implements the ObjectStoreProvider trait from lance-io.
+ *
+ * Usage:
+ *   ./lancedb_registry
+ */
+
+#include <iostream>
+#include <memory>
+#include <vector>
+#include <arrow/api.h>
+#include <arrow/c/bridge.h>
+#include "lancedb.h"
+
+// This function is provided by the external_provider crate
+// (examples/external_provider/) but is not part of the public lancedb API.
+// It creates an external ObjectStoreProvider (initialized to in-memory
+// storage for this example) to be inserted into a registry.
+extern "C" {
+LanceDBObjectStoreProvider* external_object_store_provider_create();
+}
+
+constexpr size_t DIM = 128;
+
+auto create_schema() {
+  auto id_field = arrow::field("id", arrow::int32());
+  auto item_field = arrow::field("item", arrow::fixed_size_list(arrow::float32(), DIM));
+  return arrow::schema({id_field, item_field});
+}
+
+LanceDBTable* create_empty_table(LanceDBConnection* db) {
+  auto schema = create_schema();
+  struct ArrowSchema c_schema;
+  if (const auto status = arrow::ExportSchema(*schema, &c_schema); !status.ok()) {
+    std::cerr << "failed to export schema to C ABI: " << status.ToString() << std::endl;
+    return nullptr;
+  }
+
+  const std::string table_name = "registry_example";
+  LanceDBTable* tbl = nullptr;
+  char* error_message = nullptr;
+  if (const LanceDBError result = lancedb_table_create(db, table_name.c_str(),
+      reinterpret_cast<FFI_ArrowSchema*>(&c_schema),
+      nullptr, &tbl, &error_message); result != LANCEDB_SUCCESS) {
+    std::cerr << "error creating table: " << table_name
+              << ", error: " << error_message << std::endl;
+    lancedb_free_string(error_message);
+  } else {
+    std::cout << "created table: " << table_name << " (empty)" << std::endl;
+  }
+
+  if (c_schema.release) {
+    c_schema.release(&c_schema);
+  }
+  return tbl;
+}
+
+int main() {
+  // Step 1: Create a custom ObjectStoreRegistry (comes with default providers)
+  LanceDBObjectStoreRegistry* registry = lancedb_registry_new();
+  if (!registry) {
+    std::cerr << "failed to create registry" << std::endl;
+    return 1;
+  }
+  std::cout << "created ObjectStoreRegistry with default providers" << std::endl;
+
+  // Step 2: Create an external provider and register it under a custom
+  // "custom" scheme. This demonstrates adding a new URL scheme that
+  // doesn't exist in the default registry.
+  LanceDBObjectStoreProvider* provider = external_object_store_provider_create();
+  if (!provider) {
+    std::cerr << "failed to create provider" << std::endl;
+    lancedb_registry_free(registry);
+    return 1;
+  }
+  std::cout << "created in-memory ObjectStoreProvider" << std::endl;
+
+  char* error_message = nullptr;
+  // Ownership of provider transfers to the registry here
+  if (const LanceDBError result = lancedb_registry_insert_provider(
+      registry, "custom", provider, &error_message); result != LANCEDB_SUCCESS) {
+    std::cerr << "failed to insert provider: " << error_message << std::endl;
+    lancedb_free_string(error_message);
+    lancedb_registry_free(registry);
+    return 1;
+  }
+  std::cout << "inserted provider into registry for scheme \"custom\"" << std::endl;
+
+  // Step 3: Create a session with the custom registry
+  // The session takes ownership of the registry (do not free it separately)
+  LanceDBSession* session = lancedb_session_new_with_registry(nullptr, registry);
+  if (!session) {
+    std::cerr << "failed to create session with registry" << std::endl;
+    lancedb_registry_free(registry);
+    return 1;
+  }
+  std::cout << "created session with custom registry" << std::endl;
+
+  // Step 4: Connect using the custom "custom://" scheme.
+  // This works because we registered a provider for it in step 2.
+  const std::string uri = "custom://sample-lancedb-registry";
+  LanceDBConnectBuilder* builder = lancedb_connect(uri.c_str());
+  if (!builder) {
+    std::cerr << "failed to create connection builder" << std::endl;
+    lancedb_session_free(session);
+    return 1;
+  }
+
+  builder = lancedb_connect_builder_session(builder, session);
+  if (!builder) {
+    std::cerr << "failed to set session on builder" << std::endl;
+    lancedb_session_free(session);
+    return 1;
+  }
+
+  LanceDBConnection* db = lancedb_connect_builder_execute(builder);
+  if (!db) {
+    std::cerr << "failed to connect to database" << std::endl;
+    lancedb_session_free(session);
+    return 1;
+  }
+  std::cout << "connected to: " << lancedb_connection_uri(db) << std::endl;
+
+  // Step 5: Create a table
+  auto tbl = create_empty_table(db);
+  if (!tbl) {
+    lancedb_connection_free(db);
+    lancedb_session_free(session);
+    return 1;
+  }
+  lancedb_table_free(tbl);
+
+  // Step 6: List tables
+  char** table_names = nullptr;
+  size_t name_count = 0;
+  if (const LanceDBError result = lancedb_connection_table_names(
+      db, &table_names, &name_count, &error_message); result != LANCEDB_SUCCESS) {
+    std::cerr << "error listing tables: " << error_message << std::endl;
+    lancedb_free_string(error_message);
+  } else {
+    std::cout << name_count << " table(s) found:" << std::endl;
+    for (size_t i = 0; i < name_count; i++) {
+      std::cout << "  - " << table_names[i] << std::endl;
+    }
+    lancedb_free_table_names(table_names, name_count);
+  }
+
+  // Step 7: Clean up
+  if (const LanceDBError result = lancedb_connection_drop_table(
+      db, "registry_example", nullptr, &error_message); result != LANCEDB_SUCCESS) {
+    std::cerr << "error dropping table: " << error_message << std::endl;
+    lancedb_free_string(error_message);
+  } else {
+    std::cout << "dropped table registry_example" << std::endl;
+  }
+
+  lancedb_connection_free(db);
+  lancedb_session_free(session);
+
+  std::cout << "done" << std::endl;
+  return 0;
+}

--- a/include/lancedb.h
+++ b/include/lancedb.h
@@ -61,6 +61,16 @@ typedef struct LanceDBQueryResult LanceDBQueryResult;
 typedef struct LanceDBSession LanceDBSession;
 
 /**
+ * Opaque handle to a LanceDB ObjectStoreRegistry
+ */
+typedef struct LanceDBObjectStoreRegistry LanceDBRegistry;
+
+/**
+ * Opaque handle to a LanceDB ObjectStoreProvider
+ */
+typedef struct LanceDBObjectStoreProvider LanceDBObjectStoreProvider;
+
+/**
  * Opaque handle to Arrow RecordBatchReader
  */
 typedef struct LanceDBRecordBatchReader LanceDBRecordBatchReader;
@@ -614,6 +624,75 @@ void lancedb_connection_free(LanceDBConnection* connection);
  * The returned session must be freed with lancedb_session_free().
  */
 LanceDBSession* lancedb_session_new(const LanceDBSessionOptions* options);
+
+/**
+ * Create a new session with a custom ObjectStoreRegistry
+ *
+ * @param options - pointer to LanceDBSessionOptions, or NULL for defaults
+ * @param registry - pointer to LanceDBObjectStoreRegistry, or NULL to use a default registry.
+ *
+ * - The registry must be created using "lancedb_registry_new()" API
+ * - When registry is non-NULL, this function takes ownership of it and it
+ *   will be released when the session is freed.
+ * - If registry is NULL, a default ObjectStoreRegistry is created internally.
+ *
+ * @return Non-null pointer to LanceDBSession on success, NULL on failure
+ *
+ * The returned session must be freed with lancedb_session_free().
+ */
+LanceDBSession* lancedb_session_new_with_registry( const LanceDBSessionOptions* options,
+					    const LanceDBObjectStoreRegistry* registry);
+
+/**
+ * Create a new ObjectStoreRegistry
+ *
+ * Creates a new registry with default ObjectStore providers (local filesystem, S3, etc.).
+ * After creation, custom providers can be registered which can even override the
+ * default ones for existing scheme using "lancedb_registry_insert_provider()"
+ *
+ * - If the registry created is passed to a session, ownership will be transferred
+ * - If NOT passed to a session, it must be freed with lancedb_registry_free()
+ *
+ * @return Non-null pointer to LanceDBObjectStoreRegistry on success, NULL on failure
+ */
+LanceDBObjectStoreRegistry* lancedb_registry_new(void);
+
+/**
+ * Free an ObjectStoreRegistry
+ *
+ * @param registry - pointer to LanceDBObjectStoreRegistry to free
+ *
+ * Only call this if the registry was NOT passed to any session.
+ * If the registry was passed to a session, the session owns it and will free it.
+ */
+void lancedb_registry_free(LanceDBObjectStoreRegistry* registry);
+
+/**
+ * Insert or override an ObjectStoreProvider into an ObjectStoreRegistry for a given URL scheme
+ *
+ * @param registry - pointer to LanceDBObjectStoreRegistry
+ * @param scheme - URL scheme to register the provider for (e.g., "s3")
+ * @param provider - pointer to LanceDBObjectStoreProvider. Ownership is transferred
+ *                   to the registry; do not free the provider after this call.
+ *
+ * @return 0 on success, -1 on failure
+ *
+ * If error_message is provided and an error occurs, the caller must free
+ * the error message with lancedb_free_string().
+ */
+LanceDBError lancedb_registry_insert_provider( LanceDBObjectStoreRegistry* registry,
+			    const char* scheme, LanceDBObjectStoreProvider* provider,
+    			    char** error_message);
+
+/**
+ * Free an ObjectStoreProvider
+ *
+ * @param provider - pointer to LanceDBObjectStoreProvider to free
+ *
+ * Only call this if the provider was NOT passed to lancedb_registry_insert_provider().
+ * If the provider was inserted into a registry, the registry owns it.
+ */
+void lancedb_object_store_provider_free(LanceDBObjectStoreProvider* provider);
 
 /**
  * Get index cache stats for a session

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -18,7 +18,8 @@ use lancedb::connection::{connect, ConnectBuilder, Connection, TableNamesBuilder
 use lancedb::Table;
 
 use crate::error::{
-    handle_error, set_invalid_argument_message, set_unknown_error_message, LanceDBError,
+    handle_error, set_custom_error_message, set_invalid_argument_message,
+    set_unknown_error_message, LanceDBError,
 };
 use crate::types::LanceDBRecordBatchReader;
 
@@ -52,6 +53,18 @@ pub struct LanceDBTableNamesBuilder {
 #[repr(C)]
 pub struct LanceDBSession {
     inner: Arc<lancedb::Session>,
+}
+
+/// Opaque handle to an ObjectStoreRegistry
+#[repr(C)]
+pub struct LanceDBObjectStoreRegistry {
+    inner: Arc<lancedb::ObjectStoreRegistry>,
+}
+
+/// Opaque handle to an ObjectStoreProvider
+#[repr(C)]
+pub struct LanceDBObjectStoreProvider {
+    pub inner: Option<Arc<dyn lance_io::object_store::ObjectStoreProvider>>,
 }
 
 /// Session creation options
@@ -262,6 +275,48 @@ pub unsafe extern "C" fn lancedb_connection_uri(
     cached_uri.as_ptr()
 }
 
+/// Internal helper to create a session with optional custom registry
+///
+/// # Safety
+/// - `options` can be NULL to use default session configuration
+/// - `registry` must be a valid Arc<ObjectStoreRegistry> or None for default
+unsafe fn create_session_impl(
+    options: *const LanceDBSessionOptions,
+    registry: Option<Arc<lancedb::ObjectStoreRegistry>>,
+) -> *mut LanceDBSession {
+    // Determine cache sizes from options
+    let (index_cache_bytes, metadata_cache_bytes) = if options.is_null() {
+        (
+            DEFAULT_INDEX_CACHE_SIZE_BYTES,
+            DEFAULT_METADATA_CACHE_SIZE_BYTES,
+        )
+    } else {
+        let session_options = &*options;
+        let index = if session_options.index_cache_bytes == 0 {
+            DEFAULT_INDEX_CACHE_SIZE_BYTES
+        } else {
+            session_options.index_cache_bytes
+        };
+        let metadata = if session_options.metadata_cache_bytes == 0 {
+            DEFAULT_METADATA_CACHE_SIZE_BYTES
+        } else {
+            session_options.metadata_cache_bytes
+        };
+        (index, metadata)
+    };
+
+    // Use provided registry or create default
+    let registry = registry.unwrap_or_else(|| Arc::new(lancedb::ObjectStoreRegistry::default()));
+
+    let session = Arc::new(lancedb::Session::new(
+        index_cache_bytes,
+        metadata_cache_bytes,
+        registry,
+    ));
+
+    Box::into_raw(Box::new(LanceDBSession { inner: session }))
+}
+
 /// Create a new session
 ///
 /// # Safety
@@ -274,28 +329,132 @@ pub unsafe extern "C" fn lancedb_connection_uri(
 pub unsafe extern "C" fn lancedb_session_new(
     options: *const LanceDBSessionOptions,
 ) -> *mut LanceDBSession {
-    let session = if options.is_null() {
-        Arc::new(lancedb::Session::default())
+    create_session_impl(options, None)
+}
+
+/// Create a new session with a custom ObjectStoreRegistry
+///
+/// This function allows external code to provide a custom ObjectStoreRegistry.
+///
+/// # Safety
+/// - `options` can be NULL to use default session configuration
+/// - `registry` must be a valid pointer to `LanceDBObjectStoreRegistry` created via `lancedb_registry_new()`,
+///   or NULL to use a default registry. This function takes ownership of the registry.
+///
+/// # Returns
+/// - Non-null pointer to LanceDBSession on success
+/// - Null pointer on failure
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_session_new_with_registry(
+    options: *const LanceDBSessionOptions,
+    registry: *const LanceDBObjectStoreRegistry,
+) -> *mut LanceDBSession {
+    let registry_arc = if registry.is_null() {
+        None
     } else {
-        let session_options = &*options;
-        let index_cache_bytes = if session_options.index_cache_bytes == 0 {
-            DEFAULT_INDEX_CACHE_SIZE_BYTES
-        } else {
-            session_options.index_cache_bytes
-        };
-        let metadata_cache_bytes = if session_options.metadata_cache_bytes == 0 {
-            DEFAULT_METADATA_CACHE_SIZE_BYTES
-        } else {
-            session_options.metadata_cache_bytes
-        };
-        Arc::new(lancedb::Session::new(
-            index_cache_bytes,
-            metadata_cache_bytes,
-            Arc::new(lancedb::ObjectStoreRegistry::default()),
-        ))
+        // Take ownership of the LanceDBObjectStoreRegistry
+        let registry_box = Box::from_raw(registry as *mut LanceDBObjectStoreRegistry);
+        Some(registry_box.inner)
+    };
+    create_session_impl(options, registry_arc)
+}
+
+/// Create a new ObjectStoreRegistry
+///
+/// Creates a new registry with default ObjectStore providers.
+/// The registry can be passed to `lancedb_session_new_with_registry()`.
+///
+/// # Returns
+/// - Non-null pointer to LanceDBObjectStoreRegistry on success
+/// - Null pointer on failure
+#[no_mangle]
+pub extern "C" fn lancedb_registry_new() -> *mut LanceDBObjectStoreRegistry {
+    let registry = Arc::new(lancedb::ObjectStoreRegistry::default());
+    let boxed = Box::new(LanceDBObjectStoreRegistry { inner: registry });
+    Box::into_raw(boxed)
+}
+
+/// Free an ObjectStoreRegistry
+///
+/// Only call this if the registry was NOT passed to `lancedb_session_new_with_registry()`.
+/// If the registry was passed to a session, the session owns it and will free it.
+///
+/// # Safety
+/// - `registry` must be a valid pointer returned from `lancedb_registry_new()`
+/// - `registry` must not have been passed to `lancedb_session_new_with_registry()`
+/// - `registry` must not be used after calling this function
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_registry_free(registry: *mut LanceDBObjectStoreRegistry) {
+    if !registry.is_null() {
+        let _ = Box::from_raw(registry);
+    }
+}
+
+/// Free an ObjectStoreProvider
+///
+/// Only call this if the provider was NOT passed to `lancedb_registry_insert_provider()`.
+/// If the provider was inserted into a registry, the registry owns it.
+///
+/// # Safety
+/// - `provider` must not have been passed to `lancedb_registry_insert_provider()`
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_object_store_provider_free(
+    provider: *mut LanceDBObjectStoreProvider,
+) {
+    if !provider.is_null() {
+        let _ = Box::from_raw(provider);
+    }
+}
+
+/// Insert an ObjectStoreProvider into an ObjectStoreRegistry for a given URL scheme
+///
+/// The provider's inner implementation must have been set before calling this function.
+/// Ownership of the provider is transferred to the registry.
+///
+/// # Safety
+/// - `registry` must be a valid pointer from lancedb_registry_new()
+/// - `scheme` must be a valid null-terminated C string
+/// - `provider` must be a valid pointer from lancedb_object_store_provider_new()
+///   with its inner implementation populated
+///
+/// # Returns
+/// - 0 on success
+/// - error code on failure
+#[no_mangle]
+pub unsafe extern "C" fn lancedb_registry_insert_provider(
+    registry: *mut LanceDBObjectStoreRegistry,
+    scheme: *const c_char,
+    provider: *mut LanceDBObjectStoreProvider,
+    error_message: *mut *mut c_char,
+) -> LanceDBError {
+    if registry.is_null() || scheme.is_null() || provider.is_null() {
+        set_invalid_argument_message(error_message);
+        return LanceDBError::InvalidArgument;
+    }
+
+    let scheme_str = match CStr::from_ptr(scheme).to_str() {
+        Ok(s) => s,
+        Err(_) => {
+            set_custom_error_message(error_message, "Invalid URL scheme string");
+            return LanceDBError::InvalidInput;
+        }
     };
 
-    Box::into_raw(Box::new(LanceDBSession { inner: session }))
+    let provider_box = Box::from_raw(provider);
+    let provider_arc = match provider_box.inner {
+        Some(arc) => arc,
+        None => {
+            set_custom_error_message(
+                error_message,
+                "LanceDBObjectStoreProvider is not initialized",
+            );
+            return LanceDBError::InvalidArgument;
+        }
+    };
+
+    let registry_ref = &*registry;
+    registry_ref.inner.insert(scheme_str, provider_arc);
+    LanceDBError::Success
 }
 
 /// Get index cache stats for a session

--- a/tests/test_connection.cpp
+++ b/tests/test_connection.cpp
@@ -148,6 +148,89 @@ TEST_CASE_METHOD(BaseFixture, "LanceDB Session", "[connection]") {
     LanceDBConnection* db = lancedb_connect_builder_execute(builder);
     REQUIRE(db == nullptr);
   }
+  SECTION("Create and free registry") {
+    // Test creating and freeing a registry without using it
+    LanceDBObjectStoreRegistry* registry = lancedb_registry_new();
+    REQUIRE(registry != nullptr);
+    lancedb_registry_free(registry);
+  }
+  SECTION("Create session with registry - NULL registry uses default") {
+    // NULL registry should use default ObjectStoreRegistry
+    LanceDBSession* session = lancedb_session_new_with_registry(nullptr, nullptr);
+    REQUIRE(session != nullptr);
+    lancedb_session_free(session);
+  }
+  SECTION("Create session with options and NULL registry") {
+    LanceDBSessionOptions options{};
+    options.index_cache_bytes = 1024 * 1024;
+    options.metadata_cache_bytes = 2 * 1024 * 1024;
+    LanceDBSession* session = lancedb_session_new_with_registry(&options, nullptr);
+    REQUIRE(session != nullptr);
+    lancedb_session_free(session);
+  }
+  SECTION("Create session with custom registry") {
+    // Create registry using C API
+    LanceDBObjectStoreRegistry* registry = lancedb_registry_new();
+    REQUIRE(registry != nullptr);
+    // Create session with custom registry (transfers ownership)
+    LanceDBSession* session = lancedb_session_new_with_registry(nullptr, registry);
+    REQUIRE(session != nullptr);
+    // Note: registry ownership transferred, don't free it
+    lancedb_session_free(session);
+  }
+  SECTION("Create session with custom registry and options") {
+    LanceDBSessionOptions options{};
+    options.index_cache_bytes = 512 * 1024 * 1024;
+    options.metadata_cache_bytes = 256 * 1024 * 1024;
+    // Create registry using C API
+    LanceDBObjectStoreRegistry* registry = lancedb_registry_new();
+    REQUIRE(registry != nullptr);
+    // Create session with custom registry and options (transfers ownership)
+    LanceDBSession* session = lancedb_session_new_with_registry(&options, registry);
+    REQUIRE(session != nullptr);
+    lancedb_session_free(session);
+  }
+  SECTION("Session with registry can be used with connection builder") {
+    LanceDBObjectStoreRegistry* registry = lancedb_registry_new();
+    REQUIRE(registry != nullptr);
+    LanceDBSession* session = lancedb_session_new_with_registry(nullptr, registry);
+    REQUIRE(session != nullptr);
+    LanceDBConnectBuilder* builder = lancedb_connect(uri.c_str());
+    REQUIRE(builder != nullptr);
+    builder = lancedb_connect_builder_session(builder, session);
+    REQUIRE(builder != nullptr);
+    LanceDBConnection* db = lancedb_connect_builder_execute(builder);
+    REQUIRE(db != nullptr);
+    lancedb_connection_free(db);
+    lancedb_session_free(session);
+  }
+  SECTION("Insert NULL provider into registry returns error") {
+    LanceDBObjectStoreRegistry* registry = lancedb_registry_new();
+    REQUIRE(registry != nullptr);
+    char* error_message = nullptr;
+    LanceDBError rc = lancedb_registry_insert_provider(registry, "s3", nullptr, &error_message);
+    REQUIRE(rc == LANCEDB_INVALID_ARGUMENT);
+    REQUIRE(error_message != nullptr);
+    lancedb_free_string(error_message);
+    lancedb_registry_free(registry);
+  }
+  SECTION("Insert provider with NULL registry returns error") {
+    char* error_message = nullptr;
+    LanceDBError rc = lancedb_registry_insert_provider(nullptr, "s3", nullptr, &error_message);
+    REQUIRE(rc == LANCEDB_INVALID_ARGUMENT);
+    REQUIRE(error_message != nullptr);
+    lancedb_free_string(error_message);
+  }
+  SECTION("Insert provider with NULL scheme returns error") {
+    LanceDBObjectStoreRegistry* registry = lancedb_registry_new();
+    REQUIRE(registry != nullptr);
+    char* error_message = nullptr;
+    LanceDBError rc = lancedb_registry_insert_provider(registry, nullptr, nullptr, &error_message);
+    REQUIRE(rc == LANCEDB_INVALID_ARGUMENT);
+    REQUIRE(error_message != nullptr);
+    lancedb_free_string(error_message);
+    lancedb_registry_free(registry);
+  }
 }
 
 TEST_CASE_METHOD(LanceDBFixture, "LanceDB Tables", "[connection]") {


### PR DESCRIPTION
Add APIs to create LanceDB ObjectStoreRegistry and pass them for session creation. This enables integration with external storage backends.

Signed-off-by: Soumya Koduri <skoduri@redhat.com>