### PR TITLE
Update lancedb_connect_builder_execute to return error code and message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7046,10 +7046,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
 dependencies = [
  "cc",
- "cfg-if 1.0.3",
+ "cfg-if 1.0.4",
  "libc",
  "psm",
- "windows-sys 0.61.1",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/examples/asio_coroutine.cpp
+++ b/examples/asio_coroutine.cpp
@@ -276,8 +276,13 @@ int main(int argc, char* argv[]) {
   // connect
   auto* builder = lancedb_connect((data_dir + "/asio-example").c_str());
   if (!builder) { std::cerr << "connect builder failed" << std::endl; return 1; }
-  auto* db = lancedb_connect_builder_execute(builder);
-  if (!db) { std::cerr << "connect failed" << std::endl; return 1; }
+  LanceDBConnection* db = nullptr;
+  char* error_msg = nullptr;
+  if (lancedb_connect_builder_execute(builder, &db, &error_msg) != LANCEDB_SUCCESS) {
+    std::cerr << "connect failed: " << (error_msg ? error_msg : "unknown") << std::endl;
+    lancedb_free_string(error_msg);
+    return 1;
+  }
 
   // create table with initial data
   std::cout << "num_vectors = " << num_vectors << std::endl;

--- a/examples/external_provider/Cargo.lock
+++ b/examples/external_provider/Cargo.lock
@@ -138,6 +138,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4381,6 +4390,7 @@ dependencies = [
  "lance-namespace",
  "lancedb",
  "libc",
+ "stacker",
  "tokio",
 ]
 
@@ -4935,6 +4945,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
 dependencies = [
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -5642,6 +5661,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -7017,6 +7046,19 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.4",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "static_assertions"

--- a/examples/full.cpp
+++ b/examples/full.cpp
@@ -101,9 +101,11 @@ int main() {
     std::cerr << "failed to create connection builder" << std::endl;
     return 1;
   }
-  LanceDBConnection* db = lancedb_connect_builder_execute(builder);
-  if (!db) {
-    std::cerr << "failed to connect to database" << std::endl;
+  LanceDBConnection* db = nullptr;
+  char* error_msg = nullptr;
+  if (const LanceDBError result = lancedb_connect_builder_execute(builder, &db, &error_msg); result != LANCEDB_SUCCESS) {
+    std::cerr << "failed to connect to database: " << (error_msg ? error_msg : "unknown") << std::endl;
+    lancedb_free_string(error_msg);
     return 1;
   }
   if (const char* connected_uri = lancedb_connection_uri(db); connected_uri) {

--- a/examples/lancedb_registry.cpp
+++ b/examples/lancedb_registry.cpp
@@ -132,9 +132,11 @@ int main() {
     return 1;
   }
 
-  LanceDBConnection* db = lancedb_connect_builder_execute(builder);
-  if (!db) {
-    std::cerr << "failed to connect to database" << std::endl;
+  LanceDBConnection* db = nullptr;
+  char* error_msg = nullptr;
+  if (const LanceDBError result = lancedb_connect_builder_execute(builder, &db, &error_msg); result != LANCEDB_SUCCESS) {
+    std::cerr << "failed to connect to database: " << (error_msg ? error_msg : "unknown") << std::endl;
+    lancedb_free_string(error_msg);
     lancedb_session_free(session);
     return 1;
   }

--- a/examples/s3.cpp
+++ b/examples/s3.cpp
@@ -84,9 +84,11 @@ int main(int argc, char** argv) {
   builder = lancedb_connect_builder_storage_option(builder, "allow_http", "true");
   builder = lancedb_connect_builder_storage_option(builder, "aws_s3_addressing_style", "path");
 
-  LanceDBConnection* db = lancedb_connect_builder_execute(builder);
-  if (!db) {
-    std::cerr << "failed to connect to database" << std::endl;
+  LanceDBConnection* db = nullptr;
+  char* error_msg = nullptr;
+  if (const LanceDBError result = lancedb_connect_builder_execute(builder, &db, &error_msg); result != LANCEDB_SUCCESS) {
+    std::cerr << "failed to connect to database: " << (error_msg ? error_msg : "unknown") << std::endl;
+    lancedb_free_string(error_msg);
     return 1;
   }
 

--- a/examples/simple.cpp
+++ b/examples/simple.cpp
@@ -229,9 +229,11 @@ int main() {
     std::cerr << "failed to create connection builder" << std::endl;
     return 1;
   }
-  LanceDBConnection* db = lancedb_connect_builder_execute(builder);
-  if (!db) {
-    std::cerr << "failed to connect to database" << std::endl;
+  LanceDBConnection* db = nullptr;
+  char* error_msg = nullptr;
+  if (const LanceDBError result = lancedb_connect_builder_execute(builder, &db, &error_msg); result != LANCEDB_SUCCESS) {
+    std::cerr << "failed to connect to database: " << (error_msg ? error_msg : "unknown") << std::endl;
+    lancedb_free_string(error_msg);
     return 1;
   }
 

--- a/include/lancedb.h
+++ b/include/lancedb.h
@@ -311,12 +311,15 @@ LanceDBConnectBuilder* lancedb_connect(const char* uri);
  * Execute the connection and return a Connection handle
  *
  * @param builder - pointer to LanceDBConnectBuilder returned from lancedb_connect()
- * @return Non-null pointer to LanceDBConnection on success, NULL on failure
+ * @param connection - pointer to receive the LanceDBConnection pointer
+ * @param error_message - optional pointer to receive detailed error message (NULL to ignore)
+ * @return Error code indicating success or failure
  *
  * On success, the builder is consumed by this function and must not be used after calling.
  * The returned connection must be freed with lancedb_connection_free().
  */
-LanceDBConnection* lancedb_connect_builder_execute(LanceDBConnectBuilder* builder);
+LanceDBError lancedb_connect_builder_execute( LanceDBConnectBuilder* builder,
+		    LanceDBConnection** connection, char** error_message);
 
 
 /**

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -125,31 +125,41 @@ pub unsafe extern "C" fn lancedb_connect(uri: *const c_char) -> *mut LanceDBConn
 /// # Safety
 /// - `builder` must be a valid pointer returned from `lancedb_connect`
 /// - `builder` will be consumed and must not be used after calling this function
+/// - `connection` must be a valid pointer to receive the connection
+/// - `error_message` can be NULL to ignore detailed error messages
 ///
 /// # Returns
-/// - Non-null pointer to LanceDBConnection on success
-/// - Null pointer on failure
+/// - Error code indicating success or failure
 #[no_mangle]
 pub unsafe extern "C" fn lancedb_connect_builder_execute(
     builder: *mut LanceDBConnectBuilder,
-) -> *mut LanceDBConnection {
+    connection: *mut *mut LanceDBConnection,
+    error_message: *mut *mut c_char,
+) -> LanceDBError {
     if builder.is_null() {
-        return ptr::null_mut();
+        set_invalid_argument_message(error_message);
+        return LanceDBError::InvalidArgument;
     }
 
     let builder_box = Box::from_raw(builder);
     let connect_builder = *builder_box.inner;
 
+    if connection.is_null() {
+        set_invalid_argument_message(error_message);
+        return LanceDBError::InvalidArgument;
+    }
+
     let runtime = get_runtime();
     match runtime.block_on(connect_builder.execute()) {
-        Ok(connection) => {
+        Ok(conn) => {
             let boxed_connection = Box::new(LanceDBConnection {
-                inner: connection,
+                inner: conn,
                 uri_cache: OnceLock::new(),
             });
-            Box::into_raw(boxed_connection)
+            *connection = Box::into_raw(boxed_connection);
+            LanceDBError::Success
         }
-        Err(_) => ptr::null_mut(),
+        Err(e) => handle_error(&e, error_message),
     }
 }
 

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -64,7 +64,7 @@ public:
   LanceDBFixture() {
     LanceDBConnectBuilder* builder = lancedb_connect(uri.c_str());
     REQUIRE(builder != nullptr);
-    db = lancedb_connect_builder_execute(builder);
+    REQUIRE(lancedb_connect_builder_execute(builder, &db, nullptr) == LANCEDB_SUCCESS);
     REQUIRE(db != nullptr);
   }
 
@@ -77,7 +77,7 @@ public:
 };
 
 class LanceDBSessionFixture : public LanceDBFixture {
-  protected: 
+  protected:
     LanceDBSession* session = nullptr;
     LanceDBSessionOptions session_options = {.index_cache_bytes = 1024 * 1024, .metadata_cache_bytes = 512 * 1024};
   public:
@@ -88,7 +88,9 @@ class LanceDBSessionFixture : public LanceDBFixture {
       session = lancedb_session_new(&session_options);
       REQUIRE(session != nullptr);
       builder = lancedb_connect_builder_session(builder, session);
-      db = lancedb_connect_builder_execute(builder);
+      char* error_message = nullptr;
+      REQUIRE(lancedb_connect_builder_execute(builder, &db, &error_message) == LANCEDB_SUCCESS);
+      REQUIRE(error_message == nullptr);
       REQUIRE(db != nullptr);
     }
 

--- a/tests/test_connection.cpp
+++ b/tests/test_connection.cpp
@@ -26,7 +26,8 @@ TEST_CASE_METHOD(BaseFixture, "LanceDB Connection Builder", "[connection]") {
     REQUIRE(builder != nullptr);
     builder = lancedb_connect_builder_session(builder, nullptr);
     REQUIRE(builder != nullptr);
-    LanceDBConnection* db = lancedb_connect_builder_execute(builder);
+    LanceDBConnection* db = nullptr;
+    REQUIRE(lancedb_connect_builder_execute(builder, &db, nullptr) == LANCEDB_SUCCESS);
     REQUIRE(db != nullptr);
     lancedb_connection_free(db);
   }
@@ -70,7 +71,8 @@ TEST_CASE_METHOD(BaseFixture, "LanceDB Connection Builder", "[connection]") {
     REQUIRE(builder != nullptr);
     builder = lancedb_connect_builder_session(builder, session);
     REQUIRE(builder != nullptr);
-    LanceDBConnection* db = lancedb_connect_builder_execute(builder);
+    LanceDBConnection* db = nullptr;
+    REQUIRE(lancedb_connect_builder_execute(builder, &db, nullptr) == LANCEDB_SUCCESS);
     REQUIRE(db != nullptr);
     lancedb_connection_free(db);
     lancedb_session_free(session);
@@ -80,7 +82,8 @@ TEST_CASE_METHOD(BaseFixture, "LanceDB Connection Builder", "[connection]") {
     REQUIRE(builder != nullptr);
     builder = lancedb_connect_builder_session(builder, nullptr);
     REQUIRE(builder != nullptr);
-    LanceDBConnection* db = lancedb_connect_builder_execute(builder);
+    LanceDBConnection* db = nullptr;
+    REQUIRE(lancedb_connect_builder_execute(builder, &db, nullptr) == LANCEDB_SUCCESS);
     REQUIRE(db != nullptr);
     lancedb_connection_free(db);
   }
@@ -145,8 +148,11 @@ TEST_CASE_METHOD(BaseFixture, "LanceDB Session", "[connection]") {
     blocker.close();
 
     LanceDBConnectBuilder* builder = lancedb_connect(uri.c_str());
-    LanceDBConnection* db = lancedb_connect_builder_execute(builder);
-    REQUIRE(db == nullptr);
+    LanceDBConnection* db = nullptr;
+    char* error_message = nullptr;
+    REQUIRE(lancedb_connect_builder_execute(builder, &db, &error_message) != LANCEDB_SUCCESS);
+    REQUIRE(error_message != nullptr);
+    lancedb_free_string(error_message);
   }
   SECTION("Create and free registry") {
     // Test creating and freeing a registry without using it
@@ -199,7 +205,8 @@ TEST_CASE_METHOD(BaseFixture, "LanceDB Session", "[connection]") {
     REQUIRE(builder != nullptr);
     builder = lancedb_connect_builder_session(builder, session);
     REQUIRE(builder != nullptr);
-    LanceDBConnection* db = lancedb_connect_builder_execute(builder);
+    LanceDBConnection* db = nullptr;
+    REQUIRE(lancedb_connect_builder_execute(builder, &db, nullptr) == LANCEDB_SUCCESS);
     REQUIRE(db != nullptr);
     lancedb_connection_free(db);
     lancedb_session_free(session);


### PR DESCRIPTION
Change the API to return LanceDBError and connection & error_message by reference — matching the pattern used by lancedb_table_create and other APIs.

This fixes https://github.com/lancedb/lancedb-c/issues/56

Signed-off-by: Soumya Koduri <skoduri@redhat.com>