### PR TITLE
add a stastic library target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,16 @@ on:
 
 jobs:
   build:
-    name: Build on ${{ matrix.os }}
+    name: Build ${{ matrix.lib_type }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        lib_type: [shared]
+        include:
+          - os: ubuntu-latest
+            lib_type: static
 
     steps:
       - uses: actions/checkout@v4
@@ -45,12 +49,14 @@ jobs:
         run: |
           mkdir -p build
           cd build
-          cmake .. -G Ninja -DBUILD_EXAMPLES=ON -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release
+          cmake .. -G Ninja -DBUILD_EXAMPLES=ON -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=${{ matrix.lib_type == 'shared' && 'ON' || 'OFF' }}
 
       - name: Build
         run: ninja -C build
 
       - name: Check
+        if: matrix.lib_type == 'shared'
         run: ninja -C build check
 
       - name: Test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,16 +69,23 @@ else()
   set(RUST_TARGET_DIR "${CMAKE_BINARY_DIR}/${RUST_TARGET_DIR}/release")
   set(RUST_BUILD_TYPE "--release")
 endif()
+option(BUILD_SHARED_LIBS "Build shared library (OFF for static)" ON)
+
 set(STATIC_LIB_PATH "${RUST_TARGET_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}lancedb${CMAKE_STATIC_LIBRARY_SUFFIX}")
+set(SHARED_LIB_PATH "${RUST_TARGET_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}lancedb${CMAKE_SHARED_LIBRARY_SUFFIX}")
 if(WIN32)
   set(SHARED_LIB_PATH "${RUST_TARGET_DIR}/lancedb${CMAKE_SHARED_LIBRARY_SUFFIX}")
   set(IMPORT_LIB_PATH "${RUST_TARGET_DIR}/${CMAKE_IMPORT_LIBRARY_PREFIX}lancedb${CMAKE_IMPORT_LIBRARY_SUFFIX}")
-  set(LANCEDB_LIB_PATHS "${STATIC_LIB_PATH}" "${SHARED_LIB_PATH}" "${IMPORT_LIB_PATH}")
-else()
-  set(SHARED_LIB_PATH "${RUST_TARGET_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}lancedb${CMAKE_SHARED_LIBRARY_SUFFIX}")
-  set(LANCEDB_LIB_PATHS "${STATIC_LIB_PATH}" "${SHARED_LIB_PATH}")
 endif()
 
+if(BUILD_SHARED_LIBS)
+  set(LANCEDB_LIB_PATHS "${SHARED_LIB_PATH}")
+  if(WIN32)
+    list(APPEND LANCEDB_LIB_PATHS "${IMPORT_LIB_PATH}")
+  endif()
+else()
+  set(LANCEDB_LIB_PATHS "${STATIC_LIB_PATH}")
+endif()
 option(BUILD_EXAMPLES "Build examples" OFF)
 option(BUILD_DOCS "Build documentation" OFF)
 option(BUILD_TESTS "Build tests" OFF)
@@ -119,6 +126,10 @@ if (BUILD_EXAMPLES OR BUILD_TESTS)
   endif()
 endif()
 
+include(cmake/ProbeRustNativeLibs.cmake)
+
+configure_file(lancedb.pc.in "${CMAKE_BINARY_DIR}/lancedb.pc" @ONLY)
+
 # rust-lib target
   set(CARGO_BUILD_COMMAND cargo build ${RUST_BUILD_TYPE} ${RUST_TARGET_OPT} --target-dir "${CMAKE_BINARY_DIR}/target")
 if(BUILD_COVERAGE)
@@ -133,11 +144,20 @@ add_custom_target(rust-lib ALL
 )
 
 # lancedb target
-add_library(lancedb SHARED IMPORTED)
-set_target_properties(lancedb PROPERTIES
-  IMPORTED_LOCATION "${SHARED_LIB_PATH}"
-  IMPORTED_IMPLIB "${IMPORT_LIB_PATH}"
-)
+if(BUILD_SHARED_LIBS)
+  add_library(lancedb SHARED IMPORTED)
+  set_target_properties(lancedb PROPERTIES
+    IMPORTED_LOCATION "${SHARED_LIB_PATH}"
+    IMPORTED_IMPLIB "${IMPORT_LIB_PATH}"
+  )
+else()
+  add_library(lancedb STATIC IMPORTED)
+  set_target_properties(lancedb PROPERTIES
+    IMPORTED_LOCATION "${STATIC_LIB_PATH}"
+  )
+  set_property(TARGET lancedb PROPERTY
+    INTERFACE_LINK_LIBRARIES ${LANCEDB_NATIVE_STATIC_LIBS})
+endif()
 add_dependencies(lancedb rust-lib)
 
 
@@ -698,16 +718,26 @@ add_custom_target(check
 )
 
 # Install
-if(WIN32)
-  install(FILES "${SHARED_LIB_PATH}" DESTINATION bin)
-  install(FILES "${STATIC_LIB_PATH}" "${IMPORT_LIB_PATH}" DESTINATION lib)
+if(BUILD_SHARED_LIBS)
+  if(WIN32)
+    install(FILES "${SHARED_LIB_PATH}" DESTINATION bin)
+    install(FILES "${IMPORT_LIB_PATH}" DESTINATION lib)
+  else()
+    install(FILES "${SHARED_LIB_PATH}" DESTINATION lib)
+  endif()
 else()
-  install(FILES ${LANCEDB_LIB_PATHS} DESTINATION lib)
+  install(FILES "${STATIC_LIB_PATH}" DESTINATION lib)
 endif()
 install(DIRECTORY include/ DESTINATION include)
+install(FILES "${CMAKE_BINARY_DIR}/lancedb.pc" DESTINATION lib/pkgconfig)
 
 message(STATUS "=== LanceDB C/C++ Bindings Configuration ===")
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+if(BUILD_SHARED_LIBS)
+  message(STATUS "Library type: Shared")
+else()
+  message(STATUS "Library type: Static")
+endif()
 message(STATUS "Rust target triple: ${RUST_TARGET_TRIPLE}")
 message(STATUS "lancedb-c library paths: ${LANCEDB_LIB_PATHS}")
 if (BUILD_EXAMPLES OR BUILD_TESTS)

--- a/cmake/ProbeRustNativeLibs.cmake
+++ b/cmake/ProbeRustNativeLibs.cmake
@@ -1,0 +1,44 @@
+# Probe rustc for the native system libraries required when statically
+# linking a Rust staticlib.
+#
+# Input:  RUST_TARGET_OPT  (optional, e.g. "--target x86_64-unknown-linux-gnu")
+# Output: LANCEDB_NATIVE_STATIC_LIBS        (CMake list)
+#         LANCEDB_NATIVE_STATIC_LIBS_STRING  (space-separated, for pkg-config)
+
+if(NOT BUILD_SHARED_LIBS)
+  set(_probe_src "${CMAKE_BINARY_DIR}/_probe_native_libs.rs")
+  set(_probe_out "${CMAKE_BINARY_DIR}/_probe_native_libs${CMAKE_STATIC_LIBRARY_SUFFIX}")
+  file(WRITE "${_probe_src}" "")
+  execute_process(
+    COMMAND rustc --print native-static-libs --crate-type staticlib
+            "${_probe_src}" -o "${_probe_out}" ${RUST_TARGET_OPT}
+    ERROR_VARIABLE _rustc_stderr
+    RESULT_VARIABLE _rustc_result
+    OUTPUT_QUIET
+  )
+  file(REMOVE "${_probe_src}" "${_probe_out}")
+
+  if(_rustc_result EQUAL 0 AND _rustc_stderr MATCHES "native-static-libs: ([^\n]+)")
+    set(_raw_libs "${CMAKE_MATCH_1}")
+    separate_arguments(_lib_list NATIVE_COMMAND "${_raw_libs}")
+    set(LANCEDB_NATIVE_STATIC_LIBS "")
+    set(_pending_framework FALSE)
+    foreach(_lib IN LISTS _lib_list)
+      if(_pending_framework)
+        list(APPEND LANCEDB_NATIVE_STATIC_LIBS "-framework ${_lib}")
+        set(_pending_framework FALSE)
+      elseif(_lib STREQUAL "-framework")
+        set(_pending_framework TRUE)
+      else()
+        list(APPEND LANCEDB_NATIVE_STATIC_LIBS "${_lib}")
+      endif()
+    endforeach()
+    list(JOIN LANCEDB_NATIVE_STATIC_LIBS " " LANCEDB_NATIVE_STATIC_LIBS_STRING)
+    message(STATUS "Detected native static libraries: ${LANCEDB_NATIVE_STATIC_LIBS_STRING}")
+  else()
+    message(FATAL_ERROR "Failed to detect native static libraries for static linking. "
+      "Ensure rustc is available and supports --print native-static-libs.")
+  endif()
+else()
+  set(LANCEDB_NATIVE_STATIC_LIBS_STRING "")
+endif()

--- a/lancedb.pc.in
+++ b/lancedb.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: lancedb
+Description: LanceDB C/C++ bindings
+Version: @PROJECT_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -llancedb
+Libs.private: @LANCEDB_NATIVE_STATIC_LIBS_STRING@


### PR DESCRIPTION
also generate a .pc file, for external programs
to correctly link with it.
defauls is still a shared library.